### PR TITLE
Add some build progress output, and skip CRDs with no Schema

### DIFF
--- a/main.go
+++ b/main.go
@@ -154,6 +154,7 @@ func toMarkdown(input string) template.HTML {
 
 // WriteCRDDocs creates a CRD schema documetantation Markdown page.
 func WriteCRDDocs(crd *apiextensionsv1beta1.CustomResourceDefinition, outputFolder string) error {
+	fmt.Print("Writing CRD Docs for: " + crd.Spec.Names.Singular + " - ")
 	templateCode, err := ioutil.ReadFile(templateFolderPath + "/" + outputTemplate)
 	if err != nil {
 		return microerror.Mask(err)
@@ -280,6 +281,7 @@ func WriteCRDDocs(crd *apiextensionsv1beta1.CustomResourceDefinition, outputFold
 		fmt.Printf("%s: %s\n", outputFile, err)
 	}
 
+	fmt.Print("OK\n")
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -154,7 +154,8 @@ func toMarkdown(input string) template.HTML {
 
 // WriteCRDDocs creates a CRD schema documetantation Markdown page.
 func WriteCRDDocs(crd *apiextensionsv1beta1.CustomResourceDefinition, outputFolder string) error {
-	fmt.Print("Writing CRD Docs for: " + crd.Spec.Names.Singular + " - ")
+	fmt.Printf("Writing CRD Docs for: %s.%s - ", crd.Spec.Names.Plural, crd.Spec.Group)
+
 	templateCode, err := ioutil.ReadFile(templateFolderPath + "/" + outputTemplate)
 	if err != nil {
 		return microerror.Mask(err)
@@ -229,6 +230,12 @@ func WriteCRDDocs(crd *apiextensionsv1beta1.CustomResourceDefinition, outputFold
 				// Neither stored nore served means that this version
 				// can be skipped.
 				continue
+			}
+
+			// Guard against no Schema
+			if version.Schema == nil {
+				fmt.Printf("WARNING: %s.%s does not have a schema. Can't produce the expected output.\n", crd.Spec.Names.Plural, crd.Spec.Group)
+				return nil
 			}
 
 			// Get the first non-empty top level description and use it as the

--- a/main.go
+++ b/main.go
@@ -232,12 +232,6 @@ func WriteCRDDocs(crd *apiextensionsv1beta1.CustomResourceDefinition, outputFold
 				continue
 			}
 
-			// Guard against no Schema
-			if version.Schema == nil {
-				fmt.Printf("WARNING: %s.%s does not have a schema. Can't produce the expected output.\n", crd.Spec.Names.Plural, crd.Spec.Group)
-				return nil
-			}
-
 			// Get the first non-empty top level description and use it as the
 			// CRD description.
 			if data.Description == "" {


### PR DESCRIPTION
Gave me some insight into where an error was occuring:

```
docker run \
		-v /Users/oponder/code/giantswarm/docs/build/content/reference/cp-k8s-api:/opt/crd-docs-generator/output \
		quay.io/giantswarm/crd-docs-generator:latest
/tmp/gitclone/docs/crd/application.giantswarm.io_app.yaml
/tmp/gitclone/docs/crd/application.giantswarm.io_appcatalog.yaml
/tmp/gitclone/docs/crd/core.giantswarm.io_ignition.yaml
/tmp/gitclone/docs/crd/infrastructure.giantswarm.io_awscluster.yaml
/tmp/gitclone/docs/crd/infrastructure.giantswarm.io_awscontrolplane.yaml
/tmp/gitclone/docs/crd/infrastructure.giantswarm.io_awsmachinedeployment.yaml
/tmp/gitclone/docs/crd/infrastructure.giantswarm.io_cluster.yaml
/tmp/gitclone/docs/crd/infrastructure.giantswarm.io_machinedeployment.yaml
/tmp/gitclone/docs/crd/provider.giantswarm.io_awsconfig.yaml
/tmp/gitclone/docs/crd/release.giantswarm.io_release.yaml
Writing CRD Docs for: apps.application.giantswarm.io - OK
Writing CRD Docs for: appcatalogs.application.giantswarm.io - OK
Writing CRD Docs for: ignitions.core.giantswarm.io - OK
Writing CRD Docs for: awsclusters.infrastructure.giantswarm.io - OK
Writing CRD Docs for: awscontrolplanes.infrastructure.giantswarm.io - OK
Writing CRD Docs for: awsmachinedeployments.infrastructure.giantswarm.io - OK
Writing CRD Docs for: clusters.cluster.x-k8s.io - WARNING: clusters.cluster.x-k8s.io does not have a schema. Can't produce the expected output.
Writing CRD Docs for: machinedeployments.cluster.x-k8s.io - WARNING: machinedeployments.cluster.x-k8s.io does not have a schema. Can't produce the expected output.
Writing CRD Docs for: awsconfigs.provider.giantswarm.io - OK
Writing CRD Docs for: releases.release.giantswarm.io - OK
```

## Checklist

- [ ] Update changelog in CHANGELOG.md.
