### PR TITLE
Add repo URL and ref to output front matter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/giantswarm/microerror v0.2.0
 	github.com/huandu/xstrings v1.3.0 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
-	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.7
 	gopkg.in/russross/blackfriday.v2 v2.0.0
 	k8s.io/apiextensions-apiserver v0.17.3

--- a/templates/crd.template
+++ b/templates/crd.template
@@ -41,8 +41,8 @@ layout: "crd"
 
 {{ if .VersionSchemas }}
 {{ range $versionName, $versionSchema := .VersionSchemas }}
-<div class="crd-schema-version" id="{{$versionName}}">
-<h2>Schema for version {{$versionName}}</h2>
+<div class="crd-schema-version">
+<h2 id="{{$versionName}}">Schema for version {{$versionName}}</h2>
 
 {{ range $versionSchema.Properties }}
 <div class="property depth-{{.Depth}}" id="{{.Path}}">

--- a/templates/crd.template
+++ b/templates/crd.template
@@ -67,7 +67,7 @@ layout: "crd"
 {{ end }}
 
 {{with .ExampleCR}}
-<h2 id="crd-example-{{$versionName}}">Example CR</h2>
+<h3 id="crd-example-{{$versionName}}">Example CR</h2>
 <pre class="crd-example-cr"><code class="language-yaml">
 {{ . -}}
 </code></pre>

--- a/templates/crd.template
+++ b/templates/crd.template
@@ -11,6 +11,7 @@ date: {{ .Date }}
 weight: {{ .Weight }}
 source_repository: {{ .SourceRepository }}
 source_repository_ref: {{ .SourceRepositoryRef }}
+layout: "crd"
 ---
 
 # {{ .Title }}

--- a/templates/crd.template
+++ b/templates/crd.template
@@ -9,6 +9,8 @@ description: {{ if .Description -}}
 {{ end }}
 date: {{ .Date }}
 weight: {{ .Weight }}
+source_repository: {{ .SourceRepository }}
+source_repository_ref: {{ .SourceRepositoryRef }}
 ---
 
 # {{ .Title }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9945

This adds two fields to the front matter of generated CRD pages. Example:

```yaml
source_repository: https://github.com/giantswarm/apiextensions
source_repository_ref: master
```

In a docs template we can use that information to link to the source repository.

In addition, this adds a few more template improvements.