### PR TITLE
Place example CR in top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/tree/master
+[Unreleased]: https://github.com/giantswarm/crd-docs-generator/tree/master
 
+- Move example CR above property details
+- Fix a headline tag
 - Adapt CRD input path to match latest changes in the apiextensions repo

--- a/templates/crd.template
+++ b/templates/crd.template
@@ -42,7 +42,16 @@ layout: "crd"
 {{ if .VersionSchemas }}
 {{ range $versionName, $versionSchema := .VersionSchemas }}
 <div class="crd-schema-version">
-<h2 id="{{$versionName}}">Schema for version {{$versionName}}</h2>
+<h2 id="{{$versionName}}">Version {{$versionName}}</h2>
+
+{{with .ExampleCR}}
+<h3 id="crd-example-{{$versionName}}">Example CR</h3>
+<pre class="crd-example-cr"><code class="language-yaml">
+{{ . -}}
+</code></pre>
+{{end}}
+
+<h3 id="property-details-{{$versionName}}">Properties</h3>
 
 {{ range $versionSchema.Properties }}
 <div class="property depth-{{.Depth}}" id="{{.Path}}">
@@ -65,13 +74,6 @@ layout: "crd"
 </div>
 </div>
 {{ end }}
-
-{{with .ExampleCR}}
-<h3 id="crd-example-{{$versionName}}">Example CR</h2>
-<pre class="crd-example-cr"><code class="language-yaml">
-{{ . -}}
-</code></pre>
-{{end}}
 
 </div>
 {{end}}


### PR DESCRIPTION
This changes the CRD docs output template to have the `Example CR` section above the property details.

## Checklist

- [x] Update changelog in CHANGELOG.md.
