### PR TITLE
Move configuration into config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ workflows:
       - architect/go-build:
           name: go-build-crd-docs-generator
           binary: crd-docs-generator
+          requires:
+            - go-test-crd-docs-generato
           # filters is needed to trigger job also on git tag.
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ workflows:
           name: go-build-crd-docs-generator
           binary: crd-docs-generator
           requires:
-            - go-test-crd-docs-generato
+            - go-test-crd-docs-generator
           # filters is needed to trigger job also on git tag.
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,34 @@
-version: 2
-jobs:
-  build:
-    machine:
-      image: "ubuntu-1604:201903-01"
+version: 2.1
+orbs:
+  architect: giantswarm/architect@0.8.13
 
-    steps:
-    - checkout
+workflows:
+  build-workflow:
+    jobs:
 
-    - run:
-        name: Install architect
-        command: |
-          wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v1.0.0 | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
-          chmod +x ./architect
-          ./architect version
+      - architect/go-test:
+          name: go-test-crd-docs-generator
+          # filters is needed to trigger job also on git tag.
+          filters:
+            tags:
+              only: /^v.*/
 
-    - run:
-        name: Build using architect
-        command: ./architect build
-
-    - deploy:
-        name: architect deploy when branch is master
-        command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            ./architect deploy
-          fi
+      - architect/go-build:
+          name: go-build-crd-docs-generator
+          binary: crd-docs-generator
+          # filters is needed to trigger job also on git tag.
+          filters:
+            tags:
+              only: /^v.*/
+      
+      - architect/push-to-docker:
+          name: push-crd-docs-generator-to-quay
+          image: quay.io/giantswarm/crd-docs-generator
+          username_envar: QUAY_USERNAME
+          password_envar: QUAY_PASSWORD
+          requires:
+            - go-build-crd-docs-generator
+          # filters is needed to trigger job also on git tag.
+          filters:
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move example CR above property details
 - Fix a headline tag
 - Adapt CRD input path to match latest changes in the apiextensions repo
+- Refactor: move functions into services
+- Use config file for settings instead of flags
+- Switch CI from architect to architect-orb

--- a/README.md
+++ b/README.md
@@ -29,10 +29,15 @@ The generator can be executed in Docker using a command like this:
 ```nohighlight
 docker run \
     -v $PWD/path/to/output-folder:/opt/crd-docs-generator/output \
+    -v $PWD:/opt/crd-docs-generator/config \
     quay.io/giantswarm/crd-docs-generator \
-      --apiextensions-commit-ref v0.3.3 \
-      --skip-crd memcachedconfigs.example.giantswarm.io \
-      --skip-crd releasecycles.release.giantswarm.io
+      --config /opt/crd-docs-generator/config/config.yaml
+```
+
+or in Go like this:
+
+```nohighlight
+go run main.go --config service/config/testdata/config1.yaml
 ```
 
 The volume mapping defines where the generated output will land.

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,10 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/giantswarm/microerror v0.2.0
-	github.com/huandu/xstrings v1.3.0 // indirect
+	github.com/huandu/xstrings v1.3.1 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
-	github.com/spf13/cobra v0.0.7
+	github.com/spf13/cobra v1.0.0
 	gopkg.in/russross/blackfriday.v2 v2.0.0
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/apiextensions-apiserver v0.17.3
 )

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/huandu/xstrings v1.3.0 h1:gvV6jG9dTgFEncxo+AF7PH6MZXi/vZl25owA/8Dg8Wo=
-github.com/huandu/xstrings v1.3.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
+github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
@@ -266,8 +266,8 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
-github.com/spf13/cobra v0.0.7 h1:FfTH+vuMXOas8jmfb5/M7dzEYx7LpcLb7a0LPe34uOU=
-github.com/spf13/cobra v0.0.7/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
+github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/main.go
+++ b/main.go
@@ -3,33 +3,18 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"html/template"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
-	"time"
 
-	"github.com/Masterminds/sprig"
-	"github.com/ghodss/yaml"
+	"strings"
+
 	"github.com/giantswarm/microerror"
 	"github.com/spf13/cobra"
-	blackfriday "gopkg.in/russross/blackfriday.v2"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
+	"github.com/giantswarm/crd-docs-generator/service/config"
+	"github.com/giantswarm/crd-docs-generator/service/crd"
 	"github.com/giantswarm/crd-docs-generator/service/git"
-)
-
-const (
-	// SourceRepositoryURL is the URL to the repository defining our CRDs in Golang and YAML.
-	SourceRepositoryURL = "https://github.com/giantswarm/apiextensions"
-
-	// SourceRepositoryOrg is the Github organisation name form SourceRepositoryURL.
-	SourceRepositoryOrg = "giantswarm"
-
-	// SourceRepositoryName is the actual repo name from SourceRepositoryURL
-	SourceRepositoryName = "apiextensions"
+	"github.com/giantswarm/crd-docs-generator/service/output"
 )
 
 // CRDDocsGenerator represents an instance of this command line tool, it carries
@@ -41,10 +26,8 @@ type CRDDocsGenerator struct {
 
 	// Settings/Preferences
 
-	// The tag to use from the apiextensions repo when building crd documentation.
-	apiExtensionsTag string
-	// Which CRDs to skip. Expects whole names in the form `"thiskinds.thisgroup.io"`.
-	skipCRDs []string
+	// Path to the config file
+	configFilePath string
 }
 
 const (
@@ -65,223 +48,6 @@ const (
 	outputTemplate = "crd.template"
 )
 
-// SchemaProperty is a simplistic, flattened representation of a property
-// in a JSON Schema, without the recursion and containing only the elements
-// we intend to expose in our output.
-type SchemaProperty struct {
-	// The depth of the item in the JSONPath hierarchy
-	Depth int8
-	// Path is the full JSONpath path of the attribute, e. g. ".spec.version".
-	Path string
-	// Name is the attribute name.
-	Name string
-	// Type is the textual representaiton of the type ("object", "array", "number", "string", "boolean").
-	Type string
-	// Description is a user-friendly description of the attribute.
-	Description string
-	// Required specifies whether the property is required.
-	Required bool
-}
-
-// OutputData is all the data we pass to the HTML template for the CRD detail page.
-type OutputData struct {
-	Date                string
-	Description         string
-	Group               string
-	NamePlural          string
-	NameSingular        string
-	Scope               string
-	SourceRepository    string
-	SourceRepositoryRef string
-	Title               string
-	Weight              int
-	// Version names.
-	Versions []string
-	// Schema per version.
-	VersionSchemas map[string]OutputSchemaVersion
-}
-
-// OutputSchemaVersion is the schema information for a specific CRD version
-// we want to expose to our template.
-type OutputSchemaVersion struct {
-	Version    string
-	Properties []SchemaProperty
-	// YAML string showing an example CR.
-	ExampleCR string
-}
-
-// ReadCRD reads a CRD YAML file and returns the Custom Resource Definition object it represents.
-func ReadCRD(inputFile string) (*apiextensionsv1.CustomResourceDefinition, error) {
-	crd := &apiextensionsv1.CustomResourceDefinition{}
-
-	yamlBytes, err := ioutil.ReadFile(inputFile)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	err = yaml.Unmarshal(yamlBytes, crd)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return crd, nil
-}
-
-// flattenProperties recurses over all properties of a JSON Schema
-// and returns a flat slice of the elements we need for our output.
-func flattenProperties(schema *apiextensionsv1.JSONSchemaProps, properties []SchemaProperty, depth int8, pathPrefix string) []SchemaProperty {
-	// Capture names of required properties.
-	requiredProps := make(map[string]bool)
-	for _, p := range schema.Required {
-		requiredProps[p] = true
-	}
-
-	// Collect reduced property info.
-	for propname, schemaProps := range schema.Properties {
-		path := fmt.Sprintf("%s.%s", pathPrefix, propname)
-
-		required := false
-		if _, ok := requiredProps[propname]; ok {
-			required = true
-		}
-
-		property := SchemaProperty{
-			Depth:       depth,
-			Name:        propname,
-			Path:        path,
-			Description: schemaProps.Description,
-			Type:        schemaProps.Type,
-			Required:    required,
-		}
-
-		properties = append(properties, property)
-
-		if len(schemaProps.Properties) > 0 {
-			properties = flattenProperties(&schemaProps, properties, depth+1, path)
-		}
-
-		if schemaProps.Type == "array" && schemaProps.Items != nil {
-			// Add description of array member type
-			property := SchemaProperty{
-				Depth:       depth + 1,
-				Name:        propname + "[*]",
-				Path:        path + "[*]",
-				Description: schemaProps.Items.Schema.Description,
-				Type:        schemaProps.Items.Schema.Type,
-			}
-			properties = append(properties, property)
-
-			// Collect sub items properties
-			properties = flattenProperties(schemaProps.Items.Schema, properties, depth+2, path+"[*]")
-		}
-	}
-
-	// Sort properties by path.
-	sort.Slice(properties, func(i, j int) bool {
-		return properties[i].Path < properties[j].Path
-	})
-
-	return properties
-}
-
-func toMarkdown(input string) template.HTML {
-	inputBytes := []byte(fmt.Sprintf("%s", input))
-	return template.HTML(blackfriday.Run(inputBytes))
-}
-
-// WriteCRDDocs creates a CRD schema documetantation Markdown page.
-func WriteCRDDocs(crd *apiextensionsv1.CustomResourceDefinition, outputFolder string, repoRef string) error {
-	templateCode, err := ioutil.ReadFile(templateFolderPath + "/" + outputTemplate)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	// Add custom functions support for our template.
-	funcMap := sprig.FuncMap()
-	// Treat given test as Markdown and convert to HTML.
-	funcMap["markdown"] = toMarkdown
-	// Join strings by separator
-	funcMap["join"] = strings.Join
-
-	// Read our output template.
-	tpl := template.Must(template.New("schemapage").Funcs(funcMap).Parse(string(templateCode)))
-
-	// Collect values to pass to our output template.
-	data := OutputData{
-		// Current date as page creation date for the front matter
-		Date:                time.Now().Format("2006-01-02"),
-		Group:               crd.Spec.Group,
-		NamePlural:          crd.Spec.Names.Plural,
-		NameSingular:        crd.Spec.Names.Singular,
-		Scope:               string(crd.Spec.Scope),
-		SourceRepository:    SourceRepositoryURL,
-		SourceRepositoryRef: repoRef,
-		Title:               crd.Spec.Names.Kind,
-		Weight:              100,
-		VersionSchemas:      make(map[string]OutputSchemaVersion),
-	}
-
-	// Case B: CRD contains multiple versions and schemas.
-	for _, version := range crd.Spec.Versions {
-		if !version.Served && !version.Storage {
-			// Neither stored nore served means that this version
-			// can be skipped.
-			continue
-		}
-
-		// Get the first non-empty top level description and use it as the
-		// CRD description.
-		if data.Description == "" && version.Schema != nil {
-			data.Description = version.Schema.OpenAPIV3Schema.Description
-		}
-
-		var properties []SchemaProperty
-
-		if version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
-			properties = flattenProperties(version.Schema.OpenAPIV3Schema, properties, 0, "")
-		}
-
-		data.VersionSchemas[version.Name] = OutputSchemaVersion{
-			Version:    version.Name,
-			Properties: properties,
-		}
-
-		data.Versions = append(data.Versions, version.Name)
-	}
-
-	// Try to read example CRs for all versions.
-	for _, version := range data.Versions {
-		crFileName := fmt.Sprintf("%s/%s_%s_%s.yaml", crFolder, crd.Spec.Group, version, crd.Spec.Names.Singular)
-		exampleCR, err := ioutil.ReadFile(crFileName)
-		if err != nil {
-			fmt.Printf("Error when reading example CR file: %s\n", err)
-		} else {
-			outputSchema := data.VersionSchemas[version]
-			outputSchema.ExampleCR = string(exampleCR)
-			data.VersionSchemas[version] = outputSchema
-		}
-	}
-
-	// Name output file after full CRD name.
-	outputFile := outputFolder + "/" + crd.Spec.Names.Plural + "." + crd.Spec.Group + ".md"
-
-	handler, err := os.Create(outputFile)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = tpl.Execute(handler, data)
-	if err != nil {
-
-		// TODO: return error
-		// return microerror.Mask(err)
-
-		fmt.Printf("%s: %s\n", outputFile, err)
-	}
-
-	return nil
-}
-
 func main() {
 	var err error
 
@@ -292,12 +58,11 @@ func main() {
 			Short:        "crd-docs-generator is a command line tool for generating markdown files that document Giant Swarm's custom resources",
 			SilenceUsage: true,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return generateCrdDocs(crdDocsGenerator.apiExtensionsTag, crdDocsGenerator.skipCRDs)
+				return generateCrdDocs(crdDocsGenerator.configFilePath)
 			},
 		}
 
-		c.PersistentFlags().StringVar(&crdDocsGenerator.apiExtensionsTag, "apiextensions-commit-ref", "master", "The git commit reference (tag, branch, commit SHA) to use from the giantswarm/apiextensions repository")
-		c.PersistentFlags().StringSliceVar(&crdDocsGenerator.skipCRDs, "skip-crd", []string{}, "Name of a CRD to skip. Must use full names with plural and group in lower case. Can be used multiple times.")
+		c.PersistentFlags().StringVar(&crdDocsGenerator.configFilePath, "config", "./config.yaml", "Path to the configuration file.")
 		crdDocsGenerator.rootCommand = c
 	}
 
@@ -307,10 +72,23 @@ func main() {
 	}
 }
 
-func generateCrdDocs(apiExtensionsTag string, crdsToSkip []string) error {
+// generateCrdDocs is the function called from our main CLI command.
+func generateCrdDocs(configFilePath string) error {
+	configuration, err := config.Read(configFilePath)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	fmt.Printf("Config: %#v\n", configuration)
+	fmt.Printf("Config.SourceRepository:: %#v\n", configuration.SourceRepository)
+
 	crdFiles := []string{}
 
-	err := git.CloneRepositoryShallow(SourceRepositoryOrg, SourceRepositoryName, apiExtensionsTag, repoFolder)
+	err = git.CloneRepositoryShallow(
+		configuration.SourceRepository.Organization,
+		configuration.SourceRepository.ShortName,
+		configuration.SourceRepository.CommitReference,
+		repoFolder)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -318,6 +96,7 @@ func generateCrdDocs(apiExtensionsTag string, crdsToSkip []string) error {
 	defer os.RemoveAll(repoFolder)
 
 	err = filepath.Walk(crdFolder, func(path string, info os.FileInfo, err error) error {
+		fmt.Println(path)
 		if strings.HasSuffix(path, ".yaml") {
 			fmt.Printf("Collecting file %s\n", path)
 			crdFiles = append(crdFiles, path)
@@ -331,17 +110,24 @@ func generateCrdDocs(apiExtensionsTag string, crdsToSkip []string) error {
 	for _, crdFile := range crdFiles {
 		fmt.Printf("Reading file %s\n", crdFile)
 
-		crd, err := ReadCRD(crdFile)
+		crd, err := crd.Read(crdFile)
 		if err != nil {
 			fmt.Printf("Something went wrong in ReadCRD: %#v\n", err)
 		}
 
-		if contains(crdsToSkip, crd.Name) {
+		if contains(configuration.SkipCRDs, crd.Name) {
 			fmt.Printf("Skipping CRD %s\n", crd.Name)
 		} else {
 			fmt.Printf("Writing output for CRD %s\n", crd.Name)
 
-			err = WriteCRDDocs(crd, outputFolderPath, apiExtensionsTag)
+			err = output.WritePage(
+				crd,
+				crFolder,
+				outputFolderPath,
+				configuration.SourceRepository.URL,
+				configuration.SourceRepository.CommitReference,
+				templateFolderPath,
+				outputTemplate)
 			if err != nil {
 				fmt.Printf("Something went wrong in WriteCRDDocs: %#v\n", err)
 			}

--- a/main.go
+++ b/main.go
@@ -79,9 +79,6 @@ func generateCrdDocs(configFilePath string) error {
 		return microerror.Mask(err)
 	}
 
-	fmt.Printf("Config: %#v\n", configuration)
-	fmt.Printf("Config.SourceRepository:: %#v\n", configuration.SourceRepository)
-
 	crdFiles := []string{}
 
 	err = git.CloneRepositoryShallow(

--- a/main.go
+++ b/main.go
@@ -151,7 +151,13 @@ func contains(slice []string, item string) bool {
 func printStackTrace(err error) {
 	fmt.Println("\n--- Stack Trace ---")
 	var stackedError microerror.JSONError
-	json.Unmarshal([]byte(microerror.JSON(err)), &stackedError)
+	jsonErr := json.Unmarshal([]byte(microerror.JSON(err)), &stackedError)
+	if jsonErr != nil {
+		fmt.Println("Error when trying to Unmarshal JSON error:")
+		fmt.Printf("%#v\n", jsonErr)
+		fmt.Println("\nOriginal error:")
+		fmt.Printf("%#v\n", err)
+	}
 
 	for i, j := 0, len(stackedError.Stack)-1; i < j; i, j = i+1, j-1 {
 		stackedError.Stack[i], stackedError.Stack[j] = stackedError.Stack[j], stackedError.Stack[i]

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"io/ioutil"
+	"sort"
+
+	"github.com/giantswarm/microerror"
+	"gopkg.in/yaml.v2"
+)
+
+// FromFile represent a config file content.
+type FromFile struct {
+	SourceRepository *FromFileSourceRepository `yaml:"source_repository"`
+	SkipCRDs         []string                  `yaml:"skip_crds"`
+}
+
+// FromFileSourceRepository has details about the
+// source repository to use for CRDs.
+type FromFileSourceRepository struct {
+	URL             string `yaml:"url"`
+	Organization    string `yaml:"organization"`
+	ShortName       string `yaml:"short_name"`
+	CommitReference string `yaml:"commit_reference"`
+}
+
+// Read reads a config file and returns a struct.
+func Read(path string) (*FromFile, error) {
+	f := FromFile{}
+
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, microerror.Maskf(CouldNotReadConfigFileError, err.Error())
+	}
+
+	err = yaml.UnmarshalStrict(data, &f)
+	if err != nil {
+		return nil, microerror.Maskf(CouldNotParseConfigFileError, err.Error())
+	}
+
+	// Stable sorting for reproducible test results
+	sort.Slice(f.SkipCRDs, func(i, j int) bool {
+		return j > i
+	})
+
+	return &f, nil
+}

--- a/service/config/config_test.go
+++ b/service/config/config_test.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRead(t *testing.T) {
+	type args struct {
+		path string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *FromFile
+		wantErr bool
+	}{
+		{
+			name: "test 1 - read valid config file",
+			args: args{
+				path: "testdata/config1.yaml",
+			},
+			want: &FromFile{
+				SourceRepository: &FromFileSourceRepository{
+					URL:             "https://github.com/giantswarm/apiextensions",
+					Organization:    "giantswarm",
+					ShortName:       "apiextensions",
+					CommitReference: "v0.3.4",
+				},
+				SkipCRDs: []string{
+					"memcachedconfigs.example.giantswarm.io",
+					"releasecycles.release.giantswarm.io",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test 2 - file does not exist",
+			args: args{
+				path: "testdata/foo",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "test 3 - invalid file",
+			args: args{
+				path: "testdata/config2.yaml",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Read(tt.args.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Read() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Read() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/service/config/error.go
+++ b/service/config/error.go
@@ -1,0 +1,23 @@
+package config
+
+import "github.com/giantswarm/microerror"
+
+var CouldNotReadConfigFileError = &microerror.Error{
+	Kind: "CouldNotReadConfigFileError",
+	Desc: "The configuration file could not be read.",
+}
+
+// IsCouldNotReadConfigFile asserts CouldNotReadConfigFileError
+func IsCouldNotReadConfigFile(e error) bool {
+	return microerror.Cause(e) == CouldNotReadConfigFileError
+}
+
+var CouldNotParseConfigFileError = &microerror.Error{
+	Kind: "CouldNotParseConfigFileError",
+	Desc: "The configuration file could not be parsed.",
+}
+
+// IsCouldNotParseConfigFile asserts CouldNotParseConfigFileError
+func IsCouldNotParseConfigFile(e error) bool {
+	return microerror.Cause(e) == CouldNotParseConfigFileError
+}

--- a/service/config/testdata/config1.yaml
+++ b/service/config/testdata/config1.yaml
@@ -1,0 +1,8 @@
+source_repository:
+  url: https://github.com/giantswarm/apiextensions
+  organization: giantswarm
+  short_name: apiextensions
+  commit_reference: v0.3.4
+skip_crds:
+  - memcachedconfigs.example.giantswarm.io
+  - releasecycles.release.giantswarm.io

--- a/service/config/testdata/config2.yaml
+++ b/service/config/testdata/config2.yaml
@@ -1,0 +1,2 @@
+invalid: true
+makes: nosense

--- a/service/crd/crd.go
+++ b/service/crd/crd.go
@@ -1,0 +1,26 @@
+package crd
+
+import (
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+	"github.com/giantswarm/microerror"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// Read reads a CRD YAML file and returns the Custom Resource Definition object it represents.
+func Read(inputFile string) (*apiextensionsv1.CustomResourceDefinition, error) {
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+
+	yamlBytes, err := ioutil.ReadFile(inputFile)
+	if err != nil {
+		return nil, microerror.Maskf(CouldNotReadCRDFileError, err.Error())
+	}
+
+	err = yaml.Unmarshal(yamlBytes, crd)
+	if err != nil {
+		return nil, microerror.Maskf(CouldNotParseCRDFileError, err.Error())
+	}
+
+	return crd, nil
+}

--- a/service/crd/error.go
+++ b/service/crd/error.go
@@ -1,0 +1,23 @@
+package crd
+
+import "github.com/giantswarm/microerror"
+
+var CouldNotReadCRDFileError = &microerror.Error{
+	Kind: "CouldNotReadCRDFileError",
+	Desc: "The CRD file could not be read.",
+}
+
+// IsCouldNotReadCRDFile asserts CouldNotReadCRDFileError
+func IsCouldNotReadCRDFile(e error) bool {
+	return microerror.Cause(e) == CouldNotReadCRDFileError
+}
+
+var CouldNotParseCRDFileError = &microerror.Error{
+	Kind: "CouldNotParseCRDFileError",
+	Desc: "The CRD file could not be parsed.",
+}
+
+// IsCouldNotParseCRDFile asserts CouldNotParseCRDFileError
+func IsCouldNotParseCRDFile(e error) bool {
+	return microerror.Cause(e) == CouldNotParseCRDFileError
+}

--- a/service/git/git.go
+++ b/service/git/git.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os/exec"
 
-	errorpkg "github.com/giantswarm/crd-docs-generator/error"
 	"github.com/giantswarm/microerror"
+
+	errorpkg "github.com/giantswarm/crd-docs-generator/error"
 )
 
 // CloneRepositoryShallow will clone repository in a given directory.

--- a/service/output/output.go
+++ b/service/output/output.go
@@ -154,7 +154,7 @@ func WritePage(crd *apiextensionsv1.CustomResourceDefinition, crFolder, outputFo
 }
 
 func toMarkdown(input string) template.HTML {
-	inputBytes := []byte(fmt.Sprintf("%s", input))
+	inputBytes := []byte(input)
 	return template.HTML(blackfriday.Run(inputBytes))
 }
 

--- a/service/output/output.go
+++ b/service/output/output.go
@@ -1,0 +1,216 @@
+package output
+
+import (
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/sprig"
+	"github.com/giantswarm/microerror"
+	blackfriday "gopkg.in/russross/blackfriday.v2"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// SchemaProperty is a simplistic, flattened representation of a property
+// in a JSON Schema, without the recursion and containing only the elements
+// we intend to expose in our output.
+type SchemaProperty struct {
+	// The depth of the item in the JSONPath hierarchy
+	Depth int8
+	// Path is the full JSONpath path of the attribute, e. g. ".spec.version".
+	Path string
+	// Name is the attribute name.
+	Name string
+	// Type is the textual representaiton of the type ("object", "array", "number", "string", "boolean").
+	Type string
+	// Description is a user-friendly description of the attribute.
+	Description string
+	// Required specifies whether the property is required.
+	Required bool
+}
+
+// PageData is all the data we pass to the HTML template for the CRD detail page.
+type PageData struct {
+	Date                string
+	Description         string
+	Group               string
+	NamePlural          string
+	NameSingular        string
+	Scope               string
+	SourceRepository    string
+	SourceRepositoryRef string
+	Title               string
+	Weight              int
+	// Version names.
+	Versions []string
+	// Schema per version.
+	VersionSchemas map[string]SchemaVersion
+}
+
+// SchemaVersion is the schema information for a specific CRD version
+// we want to expose to our template.
+type SchemaVersion struct {
+	Version    string
+	Properties []SchemaProperty
+	// YAML string showing an example CR.
+	ExampleCR string
+}
+
+// WritePage creates a CRD schema documentation Markdown page.
+func WritePage(crd *apiextensionsv1.CustomResourceDefinition, crFolder, outputFolder, repoURL, repoRef, templateFolderPath, outputTemplate string) error {
+	templateCode, err := ioutil.ReadFile(templateFolderPath + "/" + outputTemplate)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Add custom functions support for our template.
+	funcMap := sprig.FuncMap()
+	// Treat given test as Markdown and convert to HTML.
+	funcMap["markdown"] = toMarkdown
+	// Join strings by separator
+	funcMap["join"] = strings.Join
+
+	// Read our output template.
+	tpl := template.Must(template.New("schemapage").Funcs(funcMap).Parse(string(templateCode)))
+
+	// Collect values to pass to our output template.
+	data := PageData{
+		// Current date as page creation date for the front matter
+		Date:                time.Now().Format("2006-01-02"),
+		Group:               crd.Spec.Group,
+		NamePlural:          crd.Spec.Names.Plural,
+		NameSingular:        crd.Spec.Names.Singular,
+		Scope:               string(crd.Spec.Scope),
+		SourceRepository:    repoURL,
+		SourceRepositoryRef: repoRef,
+		Title:               crd.Spec.Names.Kind,
+		Weight:              100,
+		VersionSchemas:      make(map[string]SchemaVersion),
+	}
+
+	// Case B: CRD contains multiple versions and schemas.
+	for _, version := range crd.Spec.Versions {
+		if !version.Served && !version.Storage {
+			// Neither stored nore served means that this version
+			// can be skipped.
+			continue
+		}
+
+		// Get the first non-empty top level description and use it as the
+		// CRD description.
+		if data.Description == "" && version.Schema != nil {
+			data.Description = version.Schema.OpenAPIV3Schema.Description
+		}
+
+		var properties []SchemaProperty
+
+		if version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
+			properties = flattenProperties(version.Schema.OpenAPIV3Schema, properties, 0, "")
+		}
+
+		data.VersionSchemas[version.Name] = SchemaVersion{
+			Version:    version.Name,
+			Properties: properties,
+		}
+
+		data.Versions = append(data.Versions, version.Name)
+	}
+
+	// Try to read example CRs for all versions.
+	for _, version := range data.Versions {
+		crFileName := fmt.Sprintf("%s/%s_%s_%s.yaml", crFolder, crd.Spec.Group, version, crd.Spec.Names.Singular)
+		exampleCR, err := ioutil.ReadFile(crFileName)
+		if err != nil {
+			fmt.Printf("Error when reading example CR file: %s\n", err)
+		} else {
+			outputSchema := data.VersionSchemas[version]
+			outputSchema.ExampleCR = string(exampleCR)
+			data.VersionSchemas[version] = outputSchema
+		}
+	}
+
+	// Name output file after full CRD name.
+	outputFile := outputFolder + "/" + crd.Spec.Names.Plural + "." + crd.Spec.Group + ".md"
+
+	handler, err := os.Create(outputFile)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = tpl.Execute(handler, data)
+	if err != nil {
+
+		// TODO: return error
+		// return microerror.Mask(err)
+
+		fmt.Printf("%s: %s\n", outputFile, err)
+	}
+
+	return nil
+}
+
+func toMarkdown(input string) template.HTML {
+	inputBytes := []byte(fmt.Sprintf("%s", input))
+	return template.HTML(blackfriday.Run(inputBytes))
+}
+
+// flattenProperties recurses over all properties of a JSON Schema
+// and returns a flat slice of the elements we need for our output.
+func flattenProperties(schema *apiextensionsv1.JSONSchemaProps, properties []SchemaProperty, depth int8, pathPrefix string) []SchemaProperty {
+	// Capture names of required properties.
+	requiredProps := make(map[string]bool)
+	for _, p := range schema.Required {
+		requiredProps[p] = true
+	}
+
+	// Collect reduced property info.
+	for propname, schemaProps := range schema.Properties {
+		path := fmt.Sprintf("%s.%s", pathPrefix, propname)
+
+		required := false
+		if _, ok := requiredProps[propname]; ok {
+			required = true
+		}
+
+		property := SchemaProperty{
+			Depth:       depth,
+			Name:        propname,
+			Path:        path,
+			Description: schemaProps.Description,
+			Type:        schemaProps.Type,
+			Required:    required,
+		}
+
+		properties = append(properties, property)
+
+		if len(schemaProps.Properties) > 0 {
+			properties = flattenProperties(&schemaProps, properties, depth+1, path)
+		}
+
+		if schemaProps.Type == "array" && schemaProps.Items != nil {
+			// Add description of array member type
+			property := SchemaProperty{
+				Depth:       depth + 1,
+				Name:        propname + "[*]",
+				Path:        path + "[*]",
+				Description: schemaProps.Items.Schema.Description,
+				Type:        schemaProps.Items.Schema.Type,
+			}
+			properties = append(properties, property)
+
+			// Collect sub items properties
+			properties = flattenProperties(schemaProps.Items.Schema, properties, depth+2, path+"[*]")
+		}
+	}
+
+	// Sort properties by path.
+	sort.Slice(properties, func(i, j int) bool {
+		return properties[i].Path < properties[j].Path
+	})
+
+	return properties
+}

--- a/service/output/output.go
+++ b/service/output/output.go
@@ -155,6 +155,8 @@ func WritePage(crd *apiextensionsv1.CustomResourceDefinition, crFolder, outputFo
 
 func toMarkdown(input string) template.HTML {
 	inputBytes := []byte(input)
+	// To mitigate gosec "this method will not auto-escape HTML. Verify data is well formed"
+	// #nosec G203
 	return template.HTML(blackfriday.Run(inputBytes))
 }
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10544

This PR represents a yak shaving journey and includes many changes:

- Main change: In order to index the same data that gets published in docs, we want the configuration of crd-docs-generator in a machine-readable file in the docs repo. The related additions are in `service/config`.
- I used the occasion to move some functions out of `main.go` into their own service.
- It turned out that architect calls the CLI expecting a `version` command. To circumvent this, I switched from architect to architect-orb.
- architect-orb does a lot stricter code linting than architect, which resulted in more changes.

The config change can be seen in use in PR https://github.com/giantswarm/docs/pull/485
