### PR TITLE
Create a link target for each attribute in the CRD reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/giantswarm/crd-docs-generator/tree/master
 
+## v0.1.1
+
+- Add a link target to every attribute name headline.
+
 ## v0.1.0
 
 - Add blacklisting feature to skip certain CRDs that should not get documented

--- a/templates/crd.template
+++ b/templates/crd.template
@@ -54,9 +54,9 @@ layout: "crd"
 <h3 id="property-details-{{$versionName}}">Properties</h3>
 
 {{ range $versionSchema.Properties }}
-<div class="property depth-{{.Depth}}" id="{{.Path}}">
+<div class="property depth-{{.Depth}}">
 <div class="property-header">
-<h3 class="property-path">{{.Path}}</h3>
+<h3 class="property-path" id="{{.Path}}">{{.Path}}</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">

--- a/templates/crd.template
+++ b/templates/crd.template
@@ -56,7 +56,7 @@ layout: "crd"
 {{ range $versionSchema.Properties }}
 <div class="property depth-{{.Depth}}">
 <div class="property-header">
-<h3 class="property-path" id="{{.Path}}">{{.Path}}</h3>
+<h3 class="property-path" id="{{$versionName}}-{{.Path}}">{{.Path}}</h3>
 </div>
 <div class="property-body">
 <div class="property-meta">


### PR DESCRIPTION
The goal of this PR is to have a link target to point to for each attribute in the CRD schema.

![image](https://user-images.githubusercontent.com/273727/86026911-51b16c00-ba30-11ea-928d-44d48c061ba6.png)


## Checklist

- [x] Update changelog in CHANGELOG.md.
