### PR TITLE
Remove whitespace around 'Required'

### DIFF
--- a/templates/crd.template
+++ b/templates/crd.template
@@ -62,9 +62,9 @@ layout: "crd"
 <div class="property-meta">
 {{with .Type}}<span class="property-type">{{.}}</span>{{end}}
 {{ if not .Required }}
-{{ else }}
+{{ else -}}
 <span class="property-required">Required</span>
-{{ end }}
+{{ end -}}
 </div>
 {{with .Description}}
 <div class="property-description">


### PR DESCRIPTION
This PR eliminates some empty lines, which can cause a markdown to HTML converter to wrap lines in extra `<p></p>` tags.

Example:

![image](https://user-images.githubusercontent.com/273727/95061659-2e1b5300-06fc-11eb-92f1-4a0ac1fa1232.png)

![image](https://user-images.githubusercontent.com/273727/95061690-37a4bb00-06fc-11eb-9d39-d048b627475a.png)
