### PR TITLE
Replace terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Change name "Control Plane Kubernetes API" to "Management Cluster API".
+
+## v0.2.0
+
 - Remove date field from front matter of generated pages, as it's no longer needed.
 
 ## v0.1.1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Generates schema reference documentation for Kubernetes Custom Resource Definitions (CRDs).
 
-This tool is built to generate our Control Plane Kubernetes API schema reference in https://docs.giantswarm.io/reference/cp-k8s-api/.
+This tool is built to generate our Management Cluster API schema reference in https://docs.giantswarm.io/reference/cp-k8s-api/.
 
 The generated output consists of Markdown files packed with HTML. By itself, this does not provide a fully readable and user-friendly set of documentation pages. Instead it relies on the HUGO website context, as the [giantswarm/docs](https://github.com/giantswarm/docs) repository, to provide an index page and useful styling.
 
@@ -44,5 +44,4 @@ The volume mapping defines where the generated output will land.
 
 ## TODO
 
-- Date in front matter should ideally reflect last modification, not docs generation
 - Parse template only once instead of for every CRD

--- a/templates/crd.template
+++ b/templates/crd.template
@@ -5,7 +5,7 @@ technical_name: {{ .NamePlural }}.{{ .Group }}
 description: {{ if .Description -}}
 {{- .Description | indent 2 }}
 {{- else -}}
-  Custom Resource/Custom Resource Definition schema reference page for the {{ .Title }} resource ({{ .NamePlural }}.{{ .Group }}), as part of the Giant Swarm Control Plane Kubernetes API documentation.
+  Custom Resource/Custom Resource Definition schema reference page for the {{ .Title }} resource ({{ .NamePlural }}.{{ .Group }}), as part of the Giant Swarm Management Cluster API documentation.
 {{ end }}
 weight: {{ .Weight }}
 source_repository: {{ .SourceRepository }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14961

This updates the name "Control Plane Kubernetes API" to "Management Cluster API".