### PR TITLE
Add flag to specify template path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add flag `--template` to specify the template path
+
 ## [0.3.0] - 2021-02-02
 
 - Don't try to add syntax highlighting. Use tripple backtick instead.

--- a/main.go
+++ b/main.go
@@ -43,12 +43,6 @@ const (
 
 	// Path for Markdown output.
 	outputFolderPath = "./output"
-
-	// Path for templates
-	templateFolderPath = "./templates"
-
-	// Single CRD page template filename (without path)
-	outputTemplate = "crd.template"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -28,6 +28,9 @@ type CRDDocsGenerator struct {
 
 	// Path to the config file
 	configFilePath string
+
+	// Path to the CRD page template file
+	templateFilePath string
 }
 
 const (
@@ -58,11 +61,12 @@ func main() {
 			Short:        "crd-docs-generator is a command line tool for generating markdown files that document Giant Swarm's custom resources",
 			SilenceUsage: true,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return generateCrdDocs(crdDocsGenerator.configFilePath)
+				return generateCrdDocs(crdDocsGenerator.configFilePath, crdDocsGenerator.templateFilePath)
 			},
 		}
 
 		c.PersistentFlags().StringVar(&crdDocsGenerator.configFilePath, "config", "./config.yaml", "Path to the configuration file.")
+		c.PersistentFlags().StringVar(&crdDocsGenerator.templateFilePath, "template", "./templates/crd.template", "Path to the CRD page template file.")
 		crdDocsGenerator.rootCommand = c
 	}
 
@@ -73,7 +77,7 @@ func main() {
 }
 
 // generateCrdDocs is the function called from our main CLI command.
-func generateCrdDocs(configFilePath string) error {
+func generateCrdDocs(configFilePath, templatePath string) error {
 	configuration, err := config.Read(configFilePath)
 	if err != nil {
 		return microerror.Mask(err)
@@ -123,8 +127,7 @@ func generateCrdDocs(configFilePath string) error {
 				outputFolderPath,
 				configuration.SourceRepository.URL,
 				configuration.SourceRepository.CommitReference,
-				templateFolderPath,
-				outputTemplate)
+				templatePath)
 			if err != nil {
 				fmt.Printf("Something went wrong in WriteCRDDocs: %#v\n", err)
 			}

--- a/service/output/output.go
+++ b/service/output/output.go
@@ -59,8 +59,8 @@ type SchemaVersion struct {
 }
 
 // WritePage creates a CRD schema documentation Markdown page.
-func WritePage(crd *apiextensionsv1.CustomResourceDefinition, crFolder, outputFolder, repoURL, repoRef, templateFolderPath, outputTemplate string) error {
-	templateCode, err := ioutil.ReadFile(templateFolderPath + "/" + outputTemplate)
+func WritePage(crd *apiextensionsv1.CustomResourceDefinition, crFolder, outputFolder, repoURL, repoRef, templatePath string) error {
+	templateCode, err := ioutil.ReadFile(templatePath)
 	if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
This PR makes the template path configurable, so we can set an external template, which will live in the giantswarm/docs repository.

## Checklist

- [x] Update changelog in CHANGELOG.md.
