### PR TITLE
Move version ref from config file to command line flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Breaking: Remove configuration option `commit_reference`, add command line flag `--version` for the same purpose instead.
+
 ## [0.4.0] - 2021-02-12
 
 - Add flag `--template` to specify the template path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Breaking: Remove configuration option `commit_reference`, add command line flag `--version` for the same purpose instead.
+- Breaking: Remove configuration option `commit_reference`, add command line flag `--commit-reference` for the same purpose instead.
 
 ## [0.4.0] - 2021-02-12
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,18 @@ docker run \
     -v $PWD/path/to/output-folder:/opt/crd-docs-generator/output \
     -v $PWD:/opt/crd-docs-generator/config \
     quay.io/giantswarm/crd-docs-generator \
-      --config /opt/crd-docs-generator/config/config.yaml
+      --version v1.2.3 \
+      --config /opt/crd-docs-generator/config/config.yaml \
+      --template /opt/crd-docs-generator/config/crd.template
 ```
 
 or in Go like this:
 
 ```nohighlight
-go run main.go --config service/config/testdata/config1.yaml
+go run main.go \
+  --config service/config/testdata/config1.yaml \
+  --version v1.2.3 \
+  --template ./crd.template
 ```
 
 The volume mapping defines where the generated output will land.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run \
     -v $PWD/path/to/output-folder:/opt/crd-docs-generator/output \
     -v $PWD:/opt/crd-docs-generator/config \
     quay.io/giantswarm/crd-docs-generator \
-      --version v1.2.3 \
+      --commit-reference v1.2.3 \
       --config /opt/crd-docs-generator/config/config.yaml \
       --template /opt/crd-docs-generator/config/crd.template
 ```
@@ -41,7 +41,7 @@ or in Go like this:
 ```nohighlight
 go run main.go \
   --config service/config/testdata/config1.yaml \
-  --version v1.2.3 \
+  --commit-reference v1.2.3 \
   --template ./crd.template
 ```
 

--- a/main.go
+++ b/main.go
@@ -38,6 +38,9 @@ type CRDDocsGenerator struct {
 
 	// Path to the CRD page template file
 	templateFilePath string
+
+	// git reference (tag, commit SHA, branch name) to check out for thee source repository
+	sourceVersionRef string
 }
 
 // Types to read annoatations documentation and CRD support
@@ -76,12 +79,15 @@ func main() {
 			Short:        "crd-docs-generator is a command line tool for generating markdown files that document Giant Swarm's custom resources",
 			SilenceUsage: true,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return generateCrdDocs(crdDocsGenerator.configFilePath, crdDocsGenerator.templateFilePath)
+				return generateCrdDocs(crdDocsGenerator.configFilePath,
+					crdDocsGenerator.templateFilePath,
+					crdDocsGenerator.sourceVersionRef)
 			},
 		}
 
 		c.PersistentFlags().StringVar(&crdDocsGenerator.configFilePath, "config", "./config.yaml", "Path to the configuration file.")
 		c.PersistentFlags().StringVar(&crdDocsGenerator.templateFilePath, "template", "./templates/crd.template", "Path to the CRD page template file.")
+		c.PersistentFlags().StringVar(&crdDocsGenerator.sourceVersionRef, "version", "main", "Commit SHA, tag or branch name to use of the CRD source repository.")
 		crdDocsGenerator.rootCommand = c
 	}
 
@@ -92,7 +98,7 @@ func main() {
 }
 
 // generateCrdDocs is the function called from our main CLI command.
-func generateCrdDocs(configFilePath, templatePath string) error {
+func generateCrdDocs(configFilePath, templatePath, versionRef string) error {
 	configuration, err := config.Read(configFilePath)
 	if err != nil {
 		return microerror.Mask(err)
@@ -104,7 +110,7 @@ func generateCrdDocs(configFilePath, templatePath string) error {
 	err = git.CloneRepositoryShallow(
 		configuration.SourceRepository.Organization,
 		configuration.SourceRepository.ShortName,
-		configuration.SourceRepository.CommitReference,
+		versionRef,
 		repoFolder)
 	if err != nil {
 		return microerror.Mask(err)

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ type CRDDocsGenerator struct {
 	// Path to the CRD page template file
 	templateFilePath string
 
-	// git reference (tag, commit SHA, branch name) to check out for thee source repository
+	// git reference (tag, commit SHA, branch name) to check out for the source repository
 	sourceCommitRef string
 }
 

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ type CRDDocsGenerator struct {
 	templateFilePath string
 
 	// git reference (tag, commit SHA, branch name) to check out for thee source repository
-	sourceVersionRef string
+	sourceCommitRef string
 }
 
 // Types to read annoatations documentation and CRD support
@@ -81,13 +81,13 @@ func main() {
 			RunE: func(cmd *cobra.Command, args []string) error {
 				return generateCrdDocs(crdDocsGenerator.configFilePath,
 					crdDocsGenerator.templateFilePath,
-					crdDocsGenerator.sourceVersionRef)
+					crdDocsGenerator.sourceCommitRef)
 			},
 		}
 
 		c.PersistentFlags().StringVar(&crdDocsGenerator.configFilePath, "config", "./config.yaml", "Path to the configuration file.")
 		c.PersistentFlags().StringVar(&crdDocsGenerator.templateFilePath, "template", "./templates/crd.template", "Path to the CRD page template file.")
-		c.PersistentFlags().StringVar(&crdDocsGenerator.sourceVersionRef, "version", "main", "Commit SHA, tag or branch name to use of the CRD source repository.")
+		c.PersistentFlags().StringVar(&crdDocsGenerator.sourceCommitRef, "commit-reference", "main", "Commit SHA, tag or branch name to use of the CRD source repository.")
 		crdDocsGenerator.rootCommand = c
 	}
 
@@ -98,7 +98,7 @@ func main() {
 }
 
 // generateCrdDocs is the function called from our main CLI command.
-func generateCrdDocs(configFilePath, templatePath, versionRef string) error {
+func generateCrdDocs(configFilePath, templatePath, commitRef string) error {
 	configuration, err := config.Read(configFilePath)
 	if err != nil {
 		return microerror.Mask(err)
@@ -110,7 +110,7 @@ func generateCrdDocs(configFilePath, templatePath, versionRef string) error {
 	err = git.CloneRepositoryShallow(
 		configuration.SourceRepository.Organization,
 		configuration.SourceRepository.ShortName,
-		versionRef,
+		commitRef,
 		repoFolder)
 	if err != nil {
 		return microerror.Mask(err)
@@ -197,7 +197,7 @@ func generateCrdDocs(configFilePath, templatePath, versionRef string) error {
 				crFolder,
 				outputFolderPath,
 				configuration.SourceRepository.URL,
-				versionRef,
+				commitRef,
 				templatePath)
 			if err != nil {
 				fmt.Printf("Something went wrong in WriteCRDDocs: %#v\n", err)

--- a/main.go
+++ b/main.go
@@ -197,7 +197,7 @@ func generateCrdDocs(configFilePath, templatePath, versionRef string) error {
 				crFolder,
 				outputFolderPath,
 				configuration.SourceRepository.URL,
-				configuration.SourceRepository.CommitReference,
+				versionRef,
 				templatePath)
 			if err != nil {
 				fmt.Printf("Something went wrong in WriteCRDDocs: %#v\n", err)

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -17,10 +17,9 @@ type FromFile struct {
 // FromFileSourceRepository has details about the
 // source repository to use for CRDs.
 type FromFileSourceRepository struct {
-	URL             string `yaml:"url"`
-	Organization    string `yaml:"organization"`
-	ShortName       string `yaml:"short_name"`
-	CommitReference string `yaml:"commit_reference"`
+	URL          string `yaml:"url"`
+	Organization string `yaml:"organization"`
+	ShortName    string `yaml:"short_name"`
 }
 
 // Read reads a config file and returns a struct.

--- a/service/config/config_test.go
+++ b/service/config/config_test.go
@@ -22,10 +22,9 @@ func TestRead(t *testing.T) {
 			},
 			want: &FromFile{
 				SourceRepository: &FromFileSourceRepository{
-					URL:             "https://github.com/giantswarm/apiextensions",
-					Organization:    "giantswarm",
-					ShortName:       "apiextensions",
-					CommitReference: "v0.3.4",
+					URL:          "https://github.com/giantswarm/apiextensions",
+					Organization: "giantswarm",
+					ShortName:    "apiextensions",
 				},
 				SkipCRDs: []string{
 					"memcachedconfigs.example.giantswarm.io",

--- a/service/config/testdata/config1.yaml
+++ b/service/config/testdata/config1.yaml
@@ -2,7 +2,6 @@ source_repository:
   url: https://github.com/giantswarm/apiextensions
   organization: giantswarm
   short_name: apiextensions
-  commit_reference: v0.3.4
 skip_crds:
   - memcachedconfigs.example.giantswarm.io
   - releasecycles.release.giantswarm.io


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11124

The goal here is to simplify setting a specific version of apiextensions to parse, moving the parameter from the config file to a command line flag.

## Checklist

- [x] Update changelog in CHANGELOG.md.
