### PR TITLE
Crawl upstream CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add support for another apiextensions repo path `/helm/**/upstream.yaml`.
+- Parse multiple CRDs from a single YAML file.
+
 ## [0.6.0] - 2021-05-14
 
 - Change path where to look for CRD YAML in giantswarm/apiextensions from `/config/crd/v1` to `/config/crd`.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ The generated output consists of Markdown files packed with HTML. By itself, thi
 This tool relies on:
 
 - CRDs being defined in the [giantswarm/apiextensions](https://github.com/giantswarm/apiextensions) repository
-- ... as one YAML file per CRD in the [apiextensions `config/crd` folder](https://github.com/giantswarm/apiextensions/tree/master/config/crd) folder.
+  - ... as one YAML file per CRD in the [apiextensions `config/crd` folder](https://github.com/giantswarm/apiextensions/tree/master/config/crd) folder
+  - ... or in the [apiextensions `helm` folder](https://github.com/giantswarm/apiextensions/tree/master/helm) (deeper in the structure) as a file named `upstream.yaml`.
 - CRDs providing an OpenAPIv3 validation schema
   - either in the `.spec.validation` section of a CRD containg only one version
   - or in the `.spec.versions[*].schema` position of a CRD containing multiple versions

--- a/service/crd/crd.go
+++ b/service/crd/crd.go
@@ -2,25 +2,35 @@ package crd
 
 import (
 	"io/ioutil"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/giantswarm/microerror"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
-// Read reads a CRD YAML file and returns the Custom Resource Definition object it represents.
-func Read(inputFile string) (*apiextensionsv1.CustomResourceDefinition, error) {
-	crd := &apiextensionsv1.CustomResourceDefinition{}
-
-	yamlBytes, err := ioutil.ReadFile(inputFile)
+// Read reads a CRD YAML file and returns the Custom Resource Definition objects it represents.
+func Read(filePath string) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	yamlBytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return nil, microerror.Maskf(CouldNotReadCRDFileError, err.Error())
 	}
 
-	err = yaml.Unmarshal(yamlBytes, crd)
-	if err != nil {
-		return nil, microerror.Maskf(CouldNotParseCRDFileError, err.Error())
+	// Split by "---"
+	parts := strings.Split(string(yamlBytes), "\n---\n")
+	crds := []apiextensionsv1.CustomResourceDefinition{}
+
+	for _, crdYAMLString := range parts {
+		crdYAMLBytes := []byte(crdYAMLString)
+		crd := apiextensionsv1.CustomResourceDefinition{}
+
+		err = yaml.Unmarshal(crdYAMLBytes, &crd)
+		if err != nil {
+			return nil, microerror.Maskf(CouldNotParseCRDFileError, err.Error())
+		}
+
+		crds = append(crds, crd)
 	}
 
-	return crd, nil
+	return crds, nil
 }

--- a/service/crd/crd.go
+++ b/service/crd/crd.go
@@ -29,6 +29,11 @@ func Read(filePath string) ([]apiextensionsv1.CustomResourceDefinition, error) {
 			return nil, microerror.Maskf(CouldNotParseCRDFileError, err.Error())
 		}
 
+		// If we had empty parts parsed, let's skip them.
+		if crd.Name == "" {
+			continue
+		}
+
 		crds = append(crds, crd)
 	}
 

--- a/templates/crd.template
+++ b/templates/crd.template
@@ -2,11 +2,12 @@
 title: {{ .Title }} CRD schema reference
 linktitle: {{ .Title }}
 technical_name: {{ .NamePlural }}.{{ .Group }}
-description: {{ if .Description -}}
-{{- .Description | indent 2 }}
-{{- else -}}
+description: |
+{{- if .Description }}
+{{ .Description | indent 2 }}
+{{- else }}
   Custom resource definition (CRD) schema reference page for the {{ .Title }} resource ({{ .NamePlural }}.{{ .Group }}), as part of the Giant Swarm Management API documentation.
-{{ end }}
+{{- end }}
 weight: {{ .Weight }}
 source_repository: {{ .SourceRepository }}
 source_repository_ref: {{ .SourceRepositoryRef }}


### PR DESCRIPTION
Include upstream CRDs in apiextensions `/helm/**/upstream.yaml`.

Also makes the `description` field in the output template more robust. Previously it failed if the description value contained a colon.

## Checklist

- [x] Update changelog in CHANGELOG.md.
