### PR TITLE
Pass CRD deprecation info from metadata to output

### DIFF
--- a/main.go
+++ b/main.go
@@ -220,9 +220,7 @@ func generateCrdDocs(configFilePath, commitRef string) error {
 			err = output.WritePage(
 				&thisCRD,
 				annotations,
-				meta.Owner,
-				meta.Topics,
-				meta.Providers,
+				meta,
 				crFolder,
 				outputFolderPath,
 				configuration.SourceRepository.URL,

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -12,10 +12,21 @@ type Root struct {
 }
 
 type CRDItem struct {
-	Owner     []string `yaml:"owner,omitempty"`
-	Topics    []string `yaml:"topics,omitempty"`
-	Providers []string `yaml:"provider,omitempty"`
-	Hidden    bool     `yaml:"hidden,omitempty"`
+	Owners      []string     `yaml:"owner,omitempty"`
+	Topics      []string     `yaml:"topics,omitempty"`
+	Providers   []string     `yaml:"provider,omitempty"`
+	Hidden      bool         `yaml:"hidden,omitempty"`
+	Deprecation *Deprecation `yaml:"deprecation,omitempty"`
+}
+
+type Deprecation struct {
+	Info       string                 `yaml:"info,omitempty"`
+	ReplacedBy *DeprecationReplacedBy `yaml:"replaced_by,omitempty"`
+}
+
+type DeprecationReplacedBy struct {
+	FullName  string `yaml:"full_name"`
+	ShortName string `yaml:"short_name"`
 }
 
 func Read(path string) (*Root, error) {

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -21,7 +21,7 @@ func TestRead(t *testing.T) {
 			want: &Root{
 				CRDs: map[string]CRDItem{
 					"crd.with.full.info": {
-						Owner:     []string{"owner"},
+						Owners:    []string{"owner"},
 						Topics:    []string{"apps"},
 						Providers: []string{"aws", "azure"},
 						Hidden:    false,
@@ -31,6 +31,21 @@ func TestRead(t *testing.T) {
 					},
 					"only.defaults": {
 						Hidden: false,
+					},
+					"deprecated.crd": {
+						Hidden: false,
+						Deprecation: &Deprecation{
+							ReplacedBy: &DeprecationReplacedBy{
+								FullName:  "new.full.crd.name",
+								ShortName: "New",
+							},
+						},
+					},
+					"simply.deprecated.crd": {
+						Hidden: false,
+						Deprecation: &Deprecation{
+							Info: "This CRD is deprecated",
+						},
 					},
 				},
 			},

--- a/pkg/metadata/testdata/1.yaml
+++ b/pkg/metadata/testdata/1.yaml
@@ -11,3 +11,11 @@ crds:
   unpublished.crd:
     hidden: true
   only.defaults:
+  deprecated.crd:
+    deprecation:
+      replaced_by:
+        full_name:  new.full.crd.name
+        short_name: New
+  simply.deprecated.crd:
+    deprecation:
+      info: This CRD is deprecated

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -12,6 +12,8 @@ import (
 	"github.com/giantswarm/microerror"
 	blackfriday "github.com/russross/blackfriday/v2"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/giantswarm/crd-docs-generator/pkg/metadata"
 )
 
 // SchemaProperty is a simplistic, flattened representation of a property
@@ -44,12 +46,10 @@ type CRDAnnotationSupport struct {
 // PageData is all the data we pass to the HTML template for the CRD detail page.
 type PageData struct {
 	Description         string
+	Metadata            metadata.CRDItem
 	Group               string
 	NamePlural          string
 	NameSingular        string
-	Owners              []string
-	Topics              []string
-	Providers           []string
 	Scope               string
 	SourceRepository    string
 	SourceRepositoryRef string
@@ -74,9 +74,7 @@ type SchemaVersion struct {
 // WritePage creates a CRD schema documentation Markdown page.
 func WritePage(crd *apiextensionsv1.CustomResourceDefinition,
 	annotations []CRDAnnotationSupport,
-	owners []string,
-	topics []string,
-	providers []string,
+	md metadata.CRDItem,
 	crFolder,
 	outputFolder,
 	repoURL,
@@ -103,11 +101,9 @@ func WritePage(crd *apiextensionsv1.CustomResourceDefinition,
 	// Collect values to pass to our output template.
 	data := PageData{
 		Group:               crd.Spec.Group,
+		Metadata:            md,
 		NamePlural:          crd.Spec.Names.Plural,
 		NameSingular:        crd.Spec.Names.Singular,
-		Owners:              owners,
-		Topics:              topics,
-		Providers:           providers,
 		Scope:               string(crd.Spec.Scope),
 		SourceRepository:    repoURL,
 		SourceRepositoryRef: repoRef,

--- a/templates/crd.template
+++ b/templates/crd.template
@@ -22,16 +22,31 @@ crd:
     - {{ . -}}
 {{- end }}
   topics:
-{{- range .Topics }}
+{{- with .Metadata.Topics }}
+{{- range . }}
     - {{ . -}}
 {{- end }}
+{{- end }}
+{{- with .Metadata.Providers }}
   providers:
-{{- range .Providers }}
+{{- range . }}
     - {{ . -}}
+{{- end }}
+{{- end }}
+{{- with .Metadata.Deprecation }}
+  deprecation:
+{{- with .Info }}
+    info: {{ . }}
+{{- end }}
+{{- with .ReplacedBy }}
+    replaced_by:
+      full_name: {{ .FullName }}
+      short_name: {{ .ShortName }}
+{{- end }}
 {{- end }}
 layout: crd
 owner:
-{{- range .Owners }}
+{{- range .Metadata.Owners }}
   - {{ . -}}
 {{- end }}
 aliases:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18019

With https://github.com/giantswarm/apiextensions/pull/759, new data on CRD deprecation is being added to apietensions. This PR passes that data on into the output pages.

## Checklist

- [x] Update changelog in CHANGELOG.md.
