### PR TITLE
Fix G601, improve unit testing of output generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@1.1.1
+  architect: giantswarm/architect@4.1.0
 
 workflows:
   build-workflow:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Update jwt-go dependency
+- Refactoring to enable better testing
 
 ## [0.7.1] - 2021-07-21
 

--- a/main.go
+++ b/main.go
@@ -203,22 +203,22 @@ func generateCrdDocs(configFilePath, commitRef string) error {
 			fmt.Printf("Something went wrong in crd.Read: %#v\n", err)
 		}
 
-		for _, thisCRD := range crds {
+		for i := range crds {
 			// Skip hidden CRDs and CRDs with missing metadata
-			meta, ok := md.CRDs[thisCRD.Name]
+			meta, ok := md.CRDs[crds[i].Name]
 			if !ok {
-				fmt.Printf("%s - metadata is missing, skipping\n", thisCRD.Name)
+				fmt.Printf("%s - metadata is missing, skipping\n", crds[i].Name)
 				continue
 			}
 			if meta.Hidden {
-				fmt.Printf("%s - is hidden explicitly, skipping\n", thisCRD.Name)
+				fmt.Printf("%s - is hidden explicitly, skipping\n", crds[i].Name)
 				continue
 			}
 
 			templatePath := path.Dir(configFilePath) + "/" + configuration.TemplatePath
 
 			err = output.WritePage(
-				&thisCRD,
+				crds[i],
 				annotations,
 				meta,
 				crFolder,

--- a/pkg/jsonschema/jsonschema.go
+++ b/pkg/jsonschema/jsonschema.go
@@ -1,0 +1,83 @@
+package jsonschema
+
+import (
+	"fmt"
+	"sort"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// Property is a simplistic, flattened representation of a property
+// in a JSON Schema, without the recursion and containing only the elements
+// we intend to expose in our output.
+type Property struct {
+	// The depth of the item in the JSONPath hierarchy
+	Depth int8
+	// Path is the full JSONpath path of the attribute, e. g. ".spec.version".
+	Path string
+	// Name is the attribute name.
+	Name string
+	// Type is the textual representaiton of the type ("object", "array", "number", "string", "boolean").
+	Type string
+	// Description is a user-friendly description of the attribute.
+	Description string
+	// Required specifies whether the property is required.
+	Required bool
+}
+
+// Flatten recurses over all properties of a JSON Schema
+// and returns a flat slice of the elements we need for our output.
+func Flatten(schema *apiextensionsv1.JSONSchemaProps, properties []Property, depth int8, pathPrefix string) []Property {
+	// Capture names of required properties.
+	requiredProps := make(map[string]bool)
+	for _, p := range schema.Required {
+		requiredProps[p] = true
+	}
+
+	// Collect reduced property info.
+	for propname, schemaProps := range schema.Properties {
+		path := fmt.Sprintf("%s.%s", pathPrefix, propname)
+
+		required := false
+		if _, ok := requiredProps[propname]; ok {
+			required = true
+		}
+
+		property := Property{
+			Depth:       depth,
+			Name:        propname,
+			Path:        path,
+			Description: schemaProps.Description,
+			Type:        schemaProps.Type,
+			Required:    required,
+		}
+
+		properties = append(properties, property)
+
+		if len(schemaProps.Properties) > 0 {
+			properties = Flatten(&schemaProps, properties, depth+1, path)
+		}
+
+		if schemaProps.Type == "array" && schemaProps.Items != nil {
+			// Add description of array member type
+			property := Property{
+				Depth:       depth + 1,
+				Name:        propname + "[*]",
+				Path:        path + "[*]",
+				Description: schemaProps.Items.Schema.Description,
+				Type:        schemaProps.Items.Schema.Type,
+			}
+			properties = append(properties, property)
+
+			// Collect sub items properties
+			properties = Flatten(schemaProps.Items.Schema, properties, depth+2, path+"[*]")
+		}
+	}
+
+	// Sort properties by path.
+	sort.Slice(properties, func(i, j int) bool {
+		return properties[i].Path < properties[j].Path
+	})
+
+	return properties
+}

--- a/pkg/jsonschema/jsonschema.go
+++ b/pkg/jsonschema/jsonschema.go
@@ -27,7 +27,7 @@ type Property struct {
 
 // Flatten recurses over all properties of a JSON Schema
 // and returns a flat slice of the elements we need for our output.
-func Flatten(schema *apiextensionsv1.JSONSchemaProps, properties []Property, depth int8, pathPrefix string) []Property {
+func Flatten(schema apiextensionsv1.JSONSchemaProps, properties []Property, depth int8, pathPrefix string) []Property {
 	// Capture names of required properties.
 	requiredProps := make(map[string]bool)
 	for _, p := range schema.Required {
@@ -55,7 +55,7 @@ func Flatten(schema *apiextensionsv1.JSONSchemaProps, properties []Property, dep
 		properties = append(properties, property)
 
 		if len(schemaProps.Properties) > 0 {
-			properties = Flatten(&schemaProps, properties, depth+1, path)
+			properties = Flatten(schemaProps, properties, depth+1, path)
 		}
 
 		if schemaProps.Type == "array" && schemaProps.Items != nil {
@@ -70,7 +70,7 @@ func Flatten(schema *apiextensionsv1.JSONSchemaProps, properties []Property, dep
 			properties = append(properties, property)
 
 			// Collect sub items properties
-			properties = Flatten(schemaProps.Items.Schema, properties, depth+2, path+"[*]")
+			properties = Flatten(*schemaProps.Items.Schema, properties, depth+2, path+"[*]")
 		}
 	}
 

--- a/pkg/jsonschema/jsonschema_test.go
+++ b/pkg/jsonschema/jsonschema_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFlatten(t *testing.T) {
 	type args struct {
-		schema     *apiextensionsv1.JSONSchemaProps
+		schema     apiextensionsv1.JSONSchemaProps
 		properties []Property
 		depth      int8
 		pathPrefix string
@@ -22,7 +22,7 @@ func TestFlatten(t *testing.T) {
 		{
 			name: "Nested schema",
 			args: args{
-				schema: &apiextensionsv1.JSONSchemaProps{
+				schema: apiextensionsv1.JSONSchemaProps{
 					ID:          "root",
 					Description: "top description",
 					Type:        "object",

--- a/pkg/jsonschema/jsonschema_test.go
+++ b/pkg/jsonschema/jsonschema_test.go
@@ -1,0 +1,112 @@
+package jsonschema
+
+import (
+	"reflect"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestFlatten(t *testing.T) {
+	type args struct {
+		schema     *apiextensionsv1.JSONSchemaProps
+		properties []Property
+		depth      int8
+		pathPrefix string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []Property
+	}{
+		{
+			name: "Nested schema",
+			args: args{
+				schema: &apiextensionsv1.JSONSchemaProps{
+					ID:          "root",
+					Description: "top description",
+					Type:        "object",
+					Required:    []string{"required_string"},
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"required_string": {
+							ID:          "the_id",
+							Description: "A required string property",
+							Type:        "string",
+						},
+						"optional_array": {
+							Type:        "array",
+							Description: "An optional array property",
+							Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+								Schema: &apiextensionsv1.JSONSchemaProps{
+									Description: "Array item",
+									Type:        "string",
+								},
+								JSONSchemas: []apiextensionsv1.JSONSchemaProps{},
+							},
+						},
+						"optional_object": {
+							Type: "object",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"nested_number": {
+									Type: "number",
+								},
+							},
+						},
+					},
+				},
+				properties: []Property{},
+				depth:      0,
+				pathPrefix: "",
+			},
+			want: []Property{
+				{
+					Depth:       0,
+					Path:        ".optional_array",
+					Name:        "optional_array",
+					Type:        "array",
+					Description: "An optional array property",
+					Required:    false,
+				},
+				{
+					Depth:       1,
+					Path:        ".optional_array[*]",
+					Name:        "optional_array[*]",
+					Type:        "string",
+					Description: "Array item",
+					Required:    false,
+				},
+				{
+					Depth:       0,
+					Path:        ".optional_object",
+					Name:        "optional_object",
+					Type:        "object",
+					Description: "",
+					Required:    false,
+				},
+				{
+					Depth:       1,
+					Path:        ".optional_object.nested_number",
+					Name:        "nested_number",
+					Type:        "number",
+					Description: "",
+					Required:    false,
+				},
+				{
+					Depth:       0,
+					Path:        ".required_string",
+					Name:        "required_string",
+					Type:        "string",
+					Description: "A required string property",
+					Required:    true,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Flatten(tt.args.schema, tt.args.properties, tt.args.depth, tt.args.pathPrefix); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Flatten() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -112,7 +112,7 @@ func WritePage(crd *apiextensionsv1.CustomResourceDefinition,
 		var properties []jsonschema.Property
 
 		if version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
-			properties = jsonschema.Flatten(version.Schema.OpenAPIV3Schema, properties, 0, "")
+			properties = jsonschema.Flatten(*version.Schema.OpenAPIV3Schema, properties, 0, "")
 		}
 
 		data.VersionSchemas[version.Name] = SchemaVersion{

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -55,7 +55,7 @@ type SchemaVersion struct {
 }
 
 // WritePage creates a CRD schema documentation Markdown page.
-func WritePage(crd *apiextensionsv1.CustomResourceDefinition,
+func WritePage(crd apiextensionsv1.CustomResourceDefinition,
 	annotations []CRDAnnotationSupport,
 	md metadata.CRDItem,
 	crFolder,

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -13,26 +13,9 @@ import (
 	blackfriday "github.com/russross/blackfriday/v2"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
+	"github.com/giantswarm/crd-docs-generator/pkg/jsonschema"
 	"github.com/giantswarm/crd-docs-generator/pkg/metadata"
 )
-
-// SchemaProperty is a simplistic, flattened representation of a property
-// in a JSON Schema, without the recursion and containing only the elements
-// we intend to expose in our output.
-type SchemaProperty struct {
-	// The depth of the item in the JSONPath hierarchy
-	Depth int8
-	// Path is the full JSONpath path of the attribute, e. g. ".spec.version".
-	Path string
-	// Name is the attribute name.
-	Name string
-	// Type is the textual representaiton of the type ("object", "array", "number", "string", "boolean").
-	Type string
-	// Description is a user-friendly description of the attribute.
-	Description string
-	// Required specifies whether the property is required.
-	Required bool
-}
 
 // CRDAnnotationSupport represents the release and
 type CRDAnnotationSupport struct {
@@ -65,7 +48,7 @@ type PageData struct {
 // we want to expose to our template.
 type SchemaVersion struct {
 	Version    string
-	Properties []SchemaProperty
+	Properties []jsonschema.Property
 	// YAML string showing an example CR.
 	ExampleCR   string
 	Annotations []CRDAnnotationSupport
@@ -126,10 +109,10 @@ func WritePage(crd *apiextensionsv1.CustomResourceDefinition,
 			data.Description = version.Schema.OpenAPIV3Schema.Description
 		}
 
-		var properties []SchemaProperty
+		var properties []jsonschema.Property
 
 		if version.Schema != nil && version.Schema.OpenAPIV3Schema != nil {
-			properties = flattenProperties(version.Schema.OpenAPIV3Schema, properties, 0, "")
+			properties = jsonschema.Flatten(version.Schema.OpenAPIV3Schema, properties, 0, "")
 		}
 
 		data.VersionSchemas[version.Name] = SchemaVersion{
@@ -205,61 +188,4 @@ func rawString(input string) template.HTML {
 	// To mitigate gosec "this method will not auto-escape HTML. Verify data is well formed"
 	// #nosec G203
 	return template.HTML(input)
-}
-
-// flattenProperties recurses over all properties of a JSON Schema
-// and returns a flat slice of the elements we need for our output.
-func flattenProperties(schema *apiextensionsv1.JSONSchemaProps, properties []SchemaProperty, depth int8, pathPrefix string) []SchemaProperty {
-	// Capture names of required properties.
-	requiredProps := make(map[string]bool)
-	for _, p := range schema.Required {
-		requiredProps[p] = true
-	}
-
-	// Collect reduced property info.
-	for propname, schemaProps := range schema.Properties {
-		path := fmt.Sprintf("%s.%s", pathPrefix, propname)
-
-		required := false
-		if _, ok := requiredProps[propname]; ok {
-			required = true
-		}
-
-		property := SchemaProperty{
-			Depth:       depth,
-			Name:        propname,
-			Path:        path,
-			Description: schemaProps.Description,
-			Type:        schemaProps.Type,
-			Required:    required,
-		}
-
-		properties = append(properties, property)
-
-		if len(schemaProps.Properties) > 0 {
-			properties = flattenProperties(&schemaProps, properties, depth+1, path)
-		}
-
-		if schemaProps.Type == "array" && schemaProps.Items != nil {
-			// Add description of array member type
-			property := SchemaProperty{
-				Depth:       depth + 1,
-				Name:        propname + "[*]",
-				Path:        path + "[*]",
-				Description: schemaProps.Items.Schema.Description,
-				Type:        schemaProps.Items.Schema.Type,
-			}
-			properties = append(properties, property)
-
-			// Collect sub items properties
-			properties = flattenProperties(schemaProps.Items.Schema, properties, depth+2, path+"[*]")
-		}
-	}
-
-	// Sort properties by path.
-	sort.Slice(properties, func(i, j int) bool {
-		return properties[i].Path < properties[j].Path
-	})
-
-	return properties
 }


### PR DESCRIPTION
This PR fixes complaints in the latest `golangci-lint` regarding

> G601: Implicit memory aliasing in for loop

and along the lines, adds some testing.