### PR TITLE
Add configuration for apiextensions-application repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update jwt-go dependency
 - Refactoring to enable better testing
 - Add test for output package
+- Improve logging
 
 ## [0.7.1] - 2021-07-21
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,11 +7,15 @@
 
 template_path: templates/crd.template
 
+# List of repositories containing CRDs.
+# Sequence is important here if several repos provide the same CRD (based on the full name).
+# In this case, the first repo "wins". Subsequent repos adding the same CRD will result in a
+# warning.
 source_repositories:
-  - url: https://github.com/giantswarm/apiextensions
+  - url: https://github.com/giantswarm/apiextensions-application
     organization: giantswarm
-    short_name: apiextensions
-    commit_reference: v3.39.0
+    short_name: apiextensions-application
+    commit_reference: v0.1.0
     metadata:
       appcatalogs.application.giantswarm.io:
         owner:
@@ -32,6 +36,21 @@ source_repositories:
           - https://github.com/orgs/giantswarm/teams/team-honeybadger
         topics:
           - apps
+      catalogs.application.giantswarm.io:
+        owner:
+          - https://github.com/orgs/giantswarm/teams/team-honeybadger
+        topics:
+          - apps
+      charts.application.giantswarm.io:
+        owner:
+          - https://github.com/orgs/giantswarm/teams/team-honeybadger
+        topics:
+          - apps
+  - url: https://github.com/giantswarm/apiextensions
+    organization: giantswarm
+    short_name: apiextensions
+    commit_reference: v3.39.0
+    metadata:
       awsclusters.infrastructure.cluster.x-k8s.io:
         owner:
           - https://github.com/orgs/giantswarm/teams/team-phoenix
@@ -174,22 +193,12 @@ source_repositories:
         owner:
           - https://github.com/orgs/giantswarm/teams/team-phoenix
         hidden: true
-      catalogs.application.giantswarm.io:
-        owner:
-          - https://github.com/orgs/giantswarm/teams/team-honeybadger
-        topics:
-          - apps
       certconfigs.core.giantswarm.io:
         owner:
           - https://github.com/orgs/giantswarm/teams/team-cabbage
         topics:
           - managementcluster
           - workloadcluster
-      charts.application.giantswarm.io:
-        owner:
-          - https://github.com/orgs/giantswarm/teams/team-honeybadger
-        topics:
-          - apps
       chartconfigs.core.giantswarm.io:
         hidden: true
       clusterclasses.cluster.x-k8s.io:

--- a/main.go
+++ b/main.go
@@ -236,10 +236,10 @@ func generateCrdDocs(configFilePath string) error {
 				// Get example CRs for this CRD (using version as key)
 				exampleCRs := make(map[string]string)
 				for _, version := range versions {
-					crFileName := fmt.Sprintf("%s/%s_%s_%s.yaml", crFolder, crds[i].Spec.Group, version, crds[i].Spec.Names.Singular)
+					crFileName := fmt.Sprintf("%s/%s/%s_%s_%s.yaml", clonePath, crFolder, crds[i].Spec.Group, version, crds[i].Spec.Names.Singular)
 					exampleCR, err := ioutil.ReadFile(crFileName)
 					if err != nil {
-						log.Printf("WARN - repo %s - CR example is missing for %s version %s", sourceRepo.ShortName, crds[i].Name, version)
+						log.Printf("WARN - repo %s - CR example is missing for %s version %s in path %s", sourceRepo.ShortName, crds[i].Name, version, crFileName)
 					} else {
 						exampleCRs[version] = strings.TrimSpace(string(exampleCR))
 					}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io/ioutil"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -102,14 +103,22 @@ func generateCrdDocs(configFilePath string) error {
 		return microerror.Mask(err)
 	}
 
-	crdFiles := []string{}
-	annotationFiles := []string{}
+	// Full names of CRDs found
+	crdNames := make(map[string]bool)
 
-	// TODO: Loop over configured repositories
+	// Loop over configured repositories
 	defer os.RemoveAll(repoFolder)
 	for _, sourceRepo := range configuration.SourceRepositories {
+		// List of source YAML files containing CRD definitions.
+		crdFiles := make(map[string]bool)
+
+		// List of Go files containing annotation definitions.
+		annotationFiles := []string{}
+
+		log.Printf("INFO - repo %s (%s)", sourceRepo.ShortName, sourceRepo.URL)
 		clonePath := repoFolder + "/" + sourceRepo.Organization + "/" + sourceRepo.ShortName
 		// Clone the repositories containing CRDs
+		log.Printf("INFO - repo %s - cloning repository", sourceRepo.ShortName)
 		err = git.CloneRepositoryShallow(
 			sourceRepo.Organization,
 			sourceRepo.ShortName,
@@ -134,7 +143,7 @@ func generateCrdDocs(configFilePath string) error {
 		thisCRDFolder := clonePath + "/" + crdFolder
 		err = filepath.Walk(thisCRDFolder, func(path string, info os.FileInfo, err error) error {
 			if strings.HasSuffix(path, ".yaml") {
-				crdFiles = append(crdFiles, path)
+				crdFiles[path] = true
 			}
 			return nil
 		})
@@ -146,7 +155,7 @@ func generateCrdDocs(configFilePath string) error {
 		thisUpstreamCRDFolder := clonePath + "/" + upstreamCRDFolder
 		err = filepath.Walk(thisUpstreamCRDFolder, func(path string, info os.FileInfo, err error) error {
 			if strings.HasSuffix(path, upstreamFileName) {
-				crdFiles = append(crdFiles, path)
+				crdFiles[path] = true
 			}
 			return nil
 		})
@@ -170,7 +179,7 @@ func generateCrdDocs(configFilePath string) error {
 
 				err := yaml.Unmarshal([]byte(constant.Doc), &annotation)
 				if err != nil {
-					fmt.Printf("%s - %s - annotation YAML docs missing\n", annotationFile, constant.Names[0])
+					log.Printf("%s - %s - annotation YAML docs missing", annotationFile, constant.Names[0])
 				}
 
 				if annotation.Documentation != "" {
@@ -191,27 +200,36 @@ func generateCrdDocs(configFilePath string) error {
 			}
 		}
 
-		for _, crdFile := range crdFiles {
+		for crdFile := range crdFiles {
+			log.Printf("INFO - repo %s - reading CRDs from file %s", sourceRepo.ShortName, crdFile)
+
 			crds, err := crd.Read(crdFile)
 			if err != nil {
-				fmt.Printf("Something went wrong in crd.Read: %#v\n", err)
+				log.Printf("WARN - something went wrong in crd.Read for file %s: %#v", crdFile, err)
 			}
 
 			for i := range crds {
+				versions := []string{}
+				for _, v := range crds[i].Spec.Versions {
+					versions = append(versions, v.Name)
+				}
+				log.Printf("INFO - repo %s - processing CRD %s with versions %s", sourceRepo.ShortName, crds[i].Name, versions)
+
 				_, exists := crdNames[crds[i].Name]
 				if exists {
 					log.Printf("WARN - repo %s - provides CRD %s which is already added - skipping", sourceRepo.ShortName, crds[i].Name)
 					continue
 				}
 				crdNames[crds[i].Name] = true
+
 				// Skip hidden CRDs and CRDs with missing metadata
 				meta, ok := sourceRepo.Metadata[crds[i].Name]
 				if !ok {
-					fmt.Printf("%s - metadata is missing, skipping\n", crds[i].Name)
+					log.Printf("WARN - repo %s - skipping %s as no metadata found", sourceRepo.ShortName, crds[i].Name)
 					continue
 				}
 				if meta.Hidden {
-					fmt.Printf("%s - is hidden explicitly, skipping\n", crds[i].Name)
+					log.Printf("INFO - repo %s - skipping %s as hidden by configuration", sourceRepo.ShortName, crds[i].Name)
 					continue
 				}
 
@@ -227,7 +245,7 @@ func generateCrdDocs(configFilePath string) error {
 					sourceRepo.CommitReference,
 					templatePath)
 				if err != nil {
-					fmt.Printf("Something went wrong in WriteCRDDocs: %#v\n", err)
+					log.Printf("WARN - repo %s - something went wrong in WriteCRDDocs: %#v", sourceRepo.ShortName, err)
 				}
 			}
 		}
@@ -242,9 +260,9 @@ func printStackTrace(err error) {
 	jsonErr := json.Unmarshal([]byte(microerror.JSON(err)), &stackedError)
 	if jsonErr != nil {
 		fmt.Println("Error when trying to Unmarshal JSON error:")
-		fmt.Printf("%#v\n", jsonErr)
+		log.Printf("%#v", jsonErr)
 		fmt.Println("\nOriginal error:")
-		fmt.Printf("%#v\n", err)
+		log.Printf("%#v", err)
 	}
 
 	for i, j := 0, len(stackedError.Stack)-1; i < j; i, j = i+1, j-1 {
@@ -252,7 +270,7 @@ func printStackTrace(err error) {
 	}
 
 	for _, entry := range stackedError.Stack {
-		fmt.Printf("%s:%d\n", entry.File, entry.Line)
+		log.Printf("%s:%d", entry.File, entry.Line)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -198,6 +198,12 @@ func generateCrdDocs(configFilePath string) error {
 			}
 
 			for i := range crds {
+				_, exists := crdNames[crds[i].Name]
+				if exists {
+					log.Printf("WARN - repo %s - provides CRD %s which is already added - skipping", sourceRepo.ShortName, crds[i].Name)
+					continue
+				}
+				crdNames[crds[i].Name] = true
 				// Skip hidden CRDs and CRDs with missing metadata
 				meta, ok := sourceRepo.Metadata[crds[i].Name]
 				if !ok {

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ const (
 	// Within a git clone, relative path for example CRs in YAML format.
 	crFolder = "docs/cr"
 
-	annotationsFolder = repoFolder + "/pkg/annotation"
+	annotationsFolder = "/pkg/annotation"
 
 	// Path for Markdown output.
 	outputFolderPath = "./output"
@@ -129,7 +129,9 @@ func generateCrdDocs(configFilePath string) error {
 		}
 
 		// Collect annotation info
-		err = filepath.Walk(annotationsFolder, func(path string, info os.FileInfo, err error) error {
+		thisAnnotationsFolder := clonePath + "/" + annotationsFolder
+		log.Printf("INFO - repo %s - collecting annotations in %s", sourceRepo.ShortName, thisAnnotationsFolder)
+		err = filepath.Walk(thisAnnotationsFolder, func(path string, info os.FileInfo, err error) error {
 			if strings.HasSuffix(path, ".go") {
 				annotationFiles = append(annotationFiles, path)
 			}

--- a/main.go
+++ b/main.go
@@ -233,13 +233,25 @@ func generateCrdDocs(configFilePath string) error {
 					continue
 				}
 
+				// Get example CRs for this CRD (using version as key)
+				exampleCRs := make(map[string]string)
+				for _, version := range versions {
+					crFileName := fmt.Sprintf("%s/%s_%s_%s.yaml", crFolder, crds[i].Spec.Group, version, crds[i].Spec.Names.Singular)
+					exampleCR, err := ioutil.ReadFile(crFileName)
+					if err != nil {
+						log.Printf("WARN - repo %s - CR example is missing for %s version %s", sourceRepo.ShortName, crds[i].Name, version)
+					} else {
+						exampleCRs[version] = strings.TrimSpace(string(exampleCR))
+					}
+				}
+
 				templatePath := path.Dir(configFilePath) + "/" + configuration.TemplatePath
 
 				_, err = output.WritePage(
 					crds[i],
 					annotations,
 					meta,
-					crFolder,
+					exampleCRs,
 					outputFolderPath,
 					sourceRepo.URL,
 					sourceRepo.CommitReference,

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"io/ioutil"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -129,7 +130,7 @@ func WritePage(crd apiextensionsv1.CustomResourceDefinition,
 		crFileName := fmt.Sprintf("%s/%s_%s_%s.yaml", crFolder, crd.Spec.Group, version, crd.Spec.Names.Singular)
 		exampleCR, err := ioutil.ReadFile(crFileName)
 		if err != nil {
-			fmt.Printf("%s - CR example is missing\n", crd.Name)
+			log.Printf("WARN - repo %s - CR example is missing for %s version %s", repoURL, crd.Name, version)
 		} else {
 			outputSchema := data.VersionSchemas[version]
 			outputSchema.ExampleCR = string(exampleCR)

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"html/template"
 	"io/ioutil"
-	"log"
 	"os"
 	"sort"
 	"strings"
@@ -59,7 +58,7 @@ type SchemaVersion struct {
 func WritePage(crd apiextensionsv1.CustomResourceDefinition,
 	annotations []CRDAnnotationSupport,
 	md config.CRDItem,
-	crFolder,
+	examplesCRs map[string]string,
 	outputFolder,
 	repoURL,
 	repoRef,
@@ -125,15 +124,12 @@ func WritePage(crd apiextensionsv1.CustomResourceDefinition,
 		data.Versions = append(data.Versions, version.Name)
 	}
 
-	// Try to read example CRs for all versions.
+	// Add example CRs
 	for _, version := range data.Versions {
-		crFileName := fmt.Sprintf("%s/%s_%s_%s.yaml", crFolder, crd.Spec.Group, version, crd.Spec.Names.Singular)
-		exampleCR, err := ioutil.ReadFile(crFileName)
-		if err != nil {
-			log.Printf("WARN - repo %s - CR example is missing for %s version %s", repoURL, crd.Name, version)
-		} else {
+		exampleCR, ok := examplesCRs[version]
+		if ok {
 			outputSchema := data.VersionSchemas[version]
-			outputSchema.ExampleCR = string(exampleCR)
+			outputSchema.ExampleCR = exampleCR + "\n"
 			data.VersionSchemas[version] = outputSchema
 		}
 	}

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -28,7 +28,7 @@ func TestWritePage(t *testing.T) {
 		crd          apiextensionsv1.CustomResourceDefinition
 		annotations  []CRDAnnotationSupport
 		md           config.CRDItem
-		crFolder     string
+		examples     map[string]string
 		repoURL      string
 		repoRef      string
 		templatePath string
@@ -99,7 +99,9 @@ func TestWritePage(t *testing.T) {
 						},
 					},
 				},
-				crFolder:     "testdata",
+				examples: map[string]string{
+					"v1alpha1": "This is an example CR",
+				},
 				repoURL:      "https://github.com/giantswarm/my-repo",
 				repoRef:      "main",
 				templatePath: "testdata/crd.template",
@@ -116,7 +118,7 @@ func TestWritePage(t *testing.T) {
 			}
 			defer os.RemoveAll(tempDir)
 
-			resultPath, err := WritePage(tt.args.crd, tt.args.annotations, tt.args.md, tt.args.crFolder, tempDir, tt.args.repoURL, tt.args.repoRef, tt.args.templatePath)
+			resultPath, err := WritePage(tt.args.crd, tt.args.annotations, tt.args.md, tt.args.examples, tempDir, tt.args.repoURL, tt.args.repoRef, tt.args.templatePath)
 			if err != tt.wantErr {
 				t.Errorf("WritePage() error = %v, wantErr %v", err, tt.wantErr)
 				t.Logf("%s", microerror.Pretty(err, true))

--- a/pkg/output/testdata/demo.giantswarm.io_v1alpha1_demo.yaml
+++ b/pkg/output/testdata/demo.giantswarm.io_v1alpha1_demo.yaml
@@ -1,1 +1,0 @@
-This is an example CR


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/616

This

- adds https://github.com/giantswarm/apiextensions-application to the example configuration
- Moves app related CRD metadata to this repo's configuration section
- adapts the code to actually work with the new repo configuration. (My recent changes omitted a few adaptations.)
- Improve logging by using log instead of fmt, unify the log message structure, log more details

## Checklist

- [x] Update changelog in CHANGELOG.md.
