### PR TITLE
Move annotations function into separate package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Breaking: rename `.APIVersion` template field to `.CRDVersion`.
 - Support multiple source repositories
 - Update jwt-go dependency
 - Refactoring to enable better testing

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -1,0 +1,137 @@
+package annotations
+
+import (
+	"go/ast"
+	"go/doc"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"gopkg.in/yaml.v2"
+)
+
+type Annotation struct {
+	Documentation string
+	Support       []AnnotationSupportRelease
+}
+
+type AnnotationSupportRelease struct {
+	Release    string
+	APIVersion string
+	CRD        string
+}
+
+// CRDAnnotationSupport is a flattened combination of
+// annotation details and the CRD they are applicable to.
+type CRDAnnotationSupport struct {
+	Annotation    string
+	CRDName       string
+	CRDVersion    string
+	Release       string
+	Documentation string
+}
+
+// Collect finds all annotations in a folder and
+// returns them.
+func Collect(startPath string) ([]CRDAnnotationSupport, error) {
+	var annotations []CRDAnnotationSupport
+
+	files, err := findFiles(startPath)
+	if err != nil {
+		return annotations, microerror.Mask(err)
+	}
+
+	for _, annotationFile := range files {
+		fset := token.NewFileSet()
+		files := []*ast.File{
+			mustParse(fset, annotationFile),
+		}
+
+		p, err := doc.NewFromFiles(fset, files, "github.com/giantswarm/extract-go-doc/p")
+		if err != nil {
+			panic(err)
+		}
+		for _, constant := range p.Consts {
+			annotation := Annotation{}
+
+			err := yaml.UnmarshalStrict([]byte(constant.Doc), &annotation)
+			if err != nil {
+				log.Printf("WARN - Annotation in %s named %q does not provide compatible YAML docs", annotationFile, constant.Names[0])
+			}
+
+			if annotation.Documentation != "" {
+				for _, crdAPI := range annotation.Support {
+					rawAnnotation := constant.Decl.Specs[0].(*ast.ValueSpec).Values[0].(*ast.BasicLit).Value
+					annotationValue := strings.Replace(rawAnnotation, "\"", "", -1)
+
+					annotations = append(annotations, CRDAnnotationSupport{
+						Annotation:    annotationValue,
+						CRDName:       crdAPI.CRD,
+						CRDVersion:    crdAPI.APIVersion,
+						Release:       crdAPI.Release,
+						Documentation: annotation.Documentation,
+					})
+				}
+			}
+		}
+	}
+
+	return Sort(annotations), nil
+}
+
+func findFiles(startPath string) ([]string, error) {
+	annotationFiles := []string{}
+	err := filepath.Walk(startPath, func(path string, info os.FileInfo, err error) error {
+		if strings.HasSuffix(path, ".go") {
+			annotationFiles = append(annotationFiles, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return annotationFiles, microerror.Mask(err)
+	}
+
+	return annotationFiles, nil
+}
+
+func mustParse(fset *token.FileSet, filename string) *ast.File {
+	src, err := ioutil.ReadFile(filename)
+	if err != nil {
+		panic(err)
+	}
+	f, err := parser.ParseFile(fset, filename, src, parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+func FilterForCRD(annotations []CRDAnnotationSupport, crdName string, version string) []CRDAnnotationSupport {
+	var result []CRDAnnotationSupport
+
+	for _, annotation := range annotations {
+		if annotation.CRDName != crdName {
+			continue
+		}
+		if version != "" && annotation.CRDVersion != version {
+			continue
+		}
+		result = append(result, annotation)
+	}
+
+	return result
+}
+
+func Sort(annotations []CRDAnnotationSupport) []CRDAnnotationSupport {
+	sort.Slice(annotations, func(i, j int) bool {
+		return annotations[i].Annotation < annotations[j].Annotation
+	})
+
+	return annotations
+}

--- a/pkg/annotations/annotations_test.go
+++ b/pkg/annotations/annotations_test.go
@@ -1,0 +1,84 @@
+package annotations
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_findFiles(t *testing.T) {
+	type args struct {
+		startPath string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "Success",
+			args:    args{startPath: "testdata"},
+			want:    []string{"testdata/aws.go"},
+			wantErr: false,
+		},
+		{
+			name:    "Non-existing path",
+			args:    args{startPath: "dfsgdfggh"},
+			want:    []string{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findFiles(tt.args.startPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("findFiles() error = %#v, wantErr %#v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findFiles() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollect(t *testing.T) {
+	type args struct {
+		startPath string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []CRDAnnotationSupport
+		wantErr bool
+	}{
+		{
+			name: "Successful",
+			args: args{
+				startPath: "testdata",
+			},
+			want: []CRDAnnotationSupport{
+				{
+					Annotation:    "alpha.cni.aws.giantswarm.io/minimum-ip-target",
+					CRDName:       "awsclusters.infrastructure.giantswarm.io",
+					CRDVersion:    "v1alpha2",
+					Release:       "Since 14.0.0",
+					Documentation: "This annotation allows configuration of the MINIMUM_IP_TARGET parameter for AWS CNI.",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Collect(tt.args.startPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Collect() error = %#v, wantErr %#v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Collect() = %#v,\nwant %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/annotations/testdata/aws.go
+++ b/pkg/annotations/testdata/aws.go
@@ -1,0 +1,12 @@
+// This is an example Go file
+// containing special doc comments we need to
+// associate annotations with CRDs.
+package aws
+
+// support:
+//   - crd: awsclusters.infrastructure.giantswarm.io
+//     apiversion: v1alpha2
+//     release: Since 14.0.0
+// documentation:
+//   This annotation allows configuration of the MINIMUM_IP_TARGET parameter for AWS CNI.
+const AWSCNIMinimumIPTarget = "alpha.cni.aws.giantswarm.io/minimum-ip-target"

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -11,6 +11,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/crd-docs-generator/pkg/annotations"
 	"github.com/giantswarm/crd-docs-generator/pkg/config"
 )
 
@@ -26,7 +27,7 @@ func TestMain(m *testing.M) {
 func TestWritePage(t *testing.T) {
 	type args struct {
 		crd          apiextensionsv1.CustomResourceDefinition
-		annotations  []CRDAnnotationSupport
+		annotations  []annotations.CRDAnnotationSupport
 		md           config.CRDItem
 		examples     map[string]string
 		repoURL      string
@@ -85,6 +86,15 @@ func TestWritePage(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+				annotations: []annotations.CRDAnnotationSupport{
+					{
+						Annotation:    "alpha.giantswarm.io/foo",
+						CRDName:       "demos.demo.giantswarm.io",
+						CRDVersion:    "v1alpha1",
+						Release:       "Since v16.0.0",
+						Documentation: "Here is some annotation documentation.",
 					},
 				},
 				md: config.CRDItem{

--- a/pkg/output/testdata/crd.template
+++ b/pkg/output/testdata/crd.template
@@ -125,7 +125,7 @@ source_repository_ref: {{ .SourceRepositoryRef }}
 {{ range $versionSchema.Annotations }}
 <div class="annotation">
 <div class="annotation-header">
-<h3 class="annotation-path" id="{{.APIVersion}}-{{.Annotation}}">{{.Annotation}}</h3>
+<h3 class="annotation-path" id="{{.CRDVersion}}-{{.Annotation}}">{{.Annotation}}</h3>
 </div>
 <div class="annotation-body">
 <div class="annotation-meta">

--- a/pkg/output/testdata/test_01.golden
+++ b/pkg/output/testdata/test_01.golden
@@ -93,6 +93,27 @@ This is an example CR
 
 
 
+<h3 id="annotation-details-v1alpha1">Annotations</h3>
+
+
+<div class="annotation">
+<div class="annotation-header">
+<h3 class="annotation-path" id="v1alpha1-alpha.giantswarm.io/foo">alpha.giantswarm.io/foo</h3>
+</div>
+<div class="annotation-body">
+<div class="annotation-meta">
+<span class="annotation-release">Since v16.0.0</span>
+</div>
+
+<div class="annotation-description">
+<p>Here is some annotation documentation.</p>
+
+</div>
+
+</div>
+</div>
+
+
 
 </div>
 


### PR DESCRIPTION
This is a pure refactoring, to move the annotations parsing out of the main loop, into a separate package.

A template field related to annotations has been renamed from `.APIVersion` to `.CRDVersion`. This will require an update of the CRD page template in giantswarm/docs.