### PR TITLE
allow git clone repo to store crd/cr in a subdirectory, not at top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Support --gitCloneRootPath command line option for those repos that do not have config/crd, docs/cr, and helm at the root level.
+
 ## [0.8.0] - 2021-12-09
 
 - Breaking: rename `.APIVersion` template field to `.CRDVersion`.


### PR DESCRIPTION
fixes: https://github.com/giantswarm/crd-docs-generator/issues/91

## Description

I'm looking to introduce the crd-docs-generator in the Kiali project (see PR https://github.com/kiali/kiali-operator/pull/470). The CRD we are documenting is part of a Kubernetes Ansible Operator. As such, it's source repo doesn't exactly follow the pattern the crd-docs-generator is expecting. There is no top-level `config/crd` nor `docs/cr` directory. Rather than "pollute" the Kiali operator git repo with these additional top-level directories, I would like to add a top level directory "crd-docs" and then under that place the `config/crd` and `docs/cr` directory. This will better organize the Kiali CRD documentation generation files (config files as well as example CR).

Because the crd-docs-generator hardcodes the location of these top-level directories [here](https://github.com/giantswarm/crd-docs-generator/blob/v0.8.0/main.go#L42) and [here](https://github.com/giantswarm/crd-docs-generator/blob/v0.8.0/main.go#L51)  (as well as the "helm" directory [here](https://github.com/giantswarm/crd-docs-generator/blob/v0.8.0/main.go#L45)), I enhanced the `main.go` so it accepts a new command line option `--gitCloneRootPath`. If you specify this, the generator will look in that root path inside the clone to find the `config/crd` and `docs/cr` (and `helm`) input files. If you do not specify this option, the generator behaves as before (so this change is backwards compatible - behavior only changes if you specify this new option).

## How to test

I tested this PR with my Kiali branch [here](https://github.com/jmazzitelli/kiali-operator/tree/crd-gen-fix-root-dir). You can test like this:

1. Download the Kiali apigen config file and template and store them in /tmp:
```
curl -L https://raw.githubusercontent.com/jmazzitelli/kiali-operator/crd-gen-fix-root-dir/crd-docs/config/apigen-config.yaml > /tmp/apigen.yaml
curl -L https://raw.githubusercontent.com/jmazzitelli/kiali-operator/crd-gen-fix-root-dir/crd-docs/config/apigen-crd.template > /tmp/apigen-crd.template
```
2. Run the gen tool using the source in this PR, using the new option (`crd-docs` is the root path in the Kiali git clone where config/crd and docs/cr is - see [here](https://github.com/jmazzitelli/kiali-operator/tree/crd-gen-fix-root-dir/crd-docs)).
```
go run main.go --config /tmp/apigen.yaml --gitCloneRootPath crd-docs
```
3. Notice the output log messages are correct - they are reading the input files from within the crd-docs root directory:
```
022/01/22 11:57:44 INFO - repo kiali-operator (https://github.com/jmazzitelli/kiali-operator)
2022/01/22 11:57:44 INFO - repo kiali-operator - cloning repository
2022/01/22 11:57:44 INFO - repo kiali-operator - collecting annotations in /tmp/gitclone/jmazzitelli/kiali-operator//pkg/annotation
2022/01/22 11:57:44 INFO - repo kiali-operator - reading CRDs from file /tmp/gitclone/jmazzitelli/kiali-operator/crd-docs/config/crd/kiali.io_kialis.yaml
2022/01/22 11:57:44 INFO - repo kiali-operator - processing CRD kialis.kiali.io with versions [v1alpha1]
```
4. At this point, notice you have `output/kialis.kiali.io.md` with the proper Kiali CRD documentation.
 
This will help the Kiali project better integrate with this crd docs generation tool. Thanks.

## Checklist

- [x] Update changelog in CHANGELOG.md.

cc @marians 