### PR TITLE
Make source paths configured per source repository (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+Breaking: source paths are now configured in the config file.
+
+Three new configuration keys have been introduced to configure paths per source_repository:
+
+- `crd_paths`: paths to search for CRD YAML files.
+- `cr_paths`: paths to search for example CR YAML files.
+- `annotations_paths`: paths to search for Go files defining annotations.
+
+All expect array values. Paths are relative to the source repo root. See the `config.example.yaml` file to learn how to use the keys.
+
 ## [0.8.0] - 2021-12-09
 
 - Breaking: rename `.APIVersion` template field to `.CRDVersion`.

--- a/README.md
+++ b/README.md
@@ -13,16 +13,13 @@ The generated output consists of Markdown files packed with HTML. By itself, thi
 
 This tool relies on:
 
-- CRDs being defined in public source repositories
-  - ... as one YAML file per CRD in the [apiextensions `config/crd` folder](https://github.com/giantswarm/apiextensions/tree/master/config/crd) folder
-  - ... or in the [apiextensions `helm` folder](https://github.com/giantswarm/apiextensions/tree/master/helm) (deeper in the structure) as a file named `upstream.yaml`.
-- Each CRD, identified by its full name, occurs only once
+- CRDs being defined in public source repositories in YAML format.
 - CRDs providing an OpenAPIv3 validation schema
   - either in the `.spec.validation` section of a CRD containg only one version
   - or in the `.spec.versions[*].schema` position of a CRD containing multiple versions
 - OpenAPIv3 schemas containing `description` attributes for every property.
 - The topmost `description` value explaining the CRD itself. (For a CRD containing multiple versions, the first `description` found is used as such.)
-- CR examples to be found in the [apiextensions `docs/cr` folder](https://github.com/giantswarm/apiextensions/tree/master/docs/cr) as one example per YAML file.
+- CR examples to be found in the source repository/repositories as one example per YAML file.
 
 ## Usage
 
@@ -43,6 +40,8 @@ go run main.go --config config.example.yaml
 ```
 
 The volume mapping defines where the generated output will land.
+
+See the `config.example.yaml` file for an idea how to configure your source repositories.
 
 ## TODO
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,6 +16,10 @@ source_repositories:
     organization: giantswarm
     short_name: apiextensions-application
     commit_reference: v0.1.0
+    crd_paths:
+      - config/crd
+    cr_paths:
+      - docs/cr
     metadata:
       appcatalogs.application.giantswarm.io:
         owner:
@@ -50,6 +54,10 @@ source_repositories:
     organization: giantswarm
     short_name: config-controller
     commit_reference: v0.5.1
+    crd_paths:
+      - config/crd
+    cr_paths:
+      - docs/cr
     metadata:
       configs.core.giantswarm.io:
         owner:
@@ -61,6 +69,10 @@ source_repositories:
     organization: giantswarm
     short_name: silence-operator
     commit_reference: v0.4.0
+    crd_paths:
+      - config/crd
+    cr_paths:
+      - docs/cr
     metadata:
       silences.monitoring.giantswarm.io:
         owner:
@@ -70,7 +82,11 @@ source_repositories:
   - url: https://github.com/giantswarm/release-operator
     organization: giantswarm
     short_name: release-operator
-    commit_reference: v3.0.0
+    commit_reference: v3.2.0
+    crd_paths:
+      - config/crd
+    cr_paths:
+      - docs/cr
     metadata:
       releases.release.giantswarm.io:
         owner:
@@ -81,7 +97,14 @@ source_repositories:
   - url: https://github.com/giantswarm/apiextensions
     organization: giantswarm
     short_name: apiextensions
-    commit_reference: v3.39.0
+    commit_reference: v3.40.0
+    annotations_paths:
+      - pkg/annotation
+    crd_paths:
+      - config/crd
+      - helm
+    cr_paths:
+      - docs/cr
     metadata:
       awsclusters.infrastructure.cluster.x-k8s.io:
         owner:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,7 +15,7 @@ source_repositories:
   - url: https://github.com/giantswarm/apiextensions-application
     organization: giantswarm
     short_name: apiextensions-application
-    commit_reference: v0.1.0
+    commit_reference: v0.3.0
     crd_paths:
       - config/crd
     cr_paths:
@@ -82,7 +82,7 @@ source_repositories:
   - url: https://github.com/giantswarm/release-operator
     organization: giantswarm
     short_name: release-operator
-    commit_reference: v3.2.0
+    commit_reference: v3.0.1
     crd_paths:
       - config/crd
     cr_paths:
@@ -97,7 +97,7 @@ source_repositories:
   - url: https://github.com/giantswarm/apiextensions
     organization: giantswarm
     short_name: apiextensions
-    commit_reference: v3.40.0
+    commit_reference: v3.39.0
     annotations_paths:
       - pkg/annotation
     crd_paths:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,8 @@ type SourceRepository struct {
 	ShortName       string             `yaml:"short_name"`
 	Metadata        map[string]CRDItem `yaml:"metadata"`
 	CommitReference string             `yaml:"commit_reference"`
+	CRDPaths        []string           `yaml:"crd_paths"`
+	CRPaths         []string           `yaml:"cr_paths"`
 }
 
 type CRDItem struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ type SourceRepository struct {
 	ShortName       string             `yaml:"short_name"`
 	Metadata        map[string]CRDItem `yaml:"metadata"`
 	CommitReference string             `yaml:"commit_reference"`
+	AnnotationsPath []string           `yaml:"annotations_paths"`
 	CRDPaths        []string           `yaml:"crd_paths"`
 	CRPaths         []string           `yaml:"cr_paths"`
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,6 +26,8 @@ func TestRead(t *testing.T) {
 						URL:          "https://github.com/giantswarm/apiextensions",
 						Organization: "giantswarm",
 						ShortName:    "apiextensions",
+						CRDPaths:     []string{"config/crd", "helm"},
+						CRPaths:      []string{"docs/cr"},
 						Metadata: map[string]CRDItem{
 							"crd.with.full.info": {
 								Owners:    []string{"owner"},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,11 +23,12 @@ func TestRead(t *testing.T) {
 			want: &FromFile{
 				SourceRepositories: []SourceRepository{
 					{
-						URL:          "https://github.com/giantswarm/apiextensions",
-						Organization: "giantswarm",
-						ShortName:    "apiextensions",
-						CRDPaths:     []string{"config/crd", "helm"},
-						CRPaths:      []string{"docs/cr"},
+						URL:             "https://github.com/giantswarm/apiextensions",
+						Organization:    "giantswarm",
+						ShortName:       "apiextensions",
+						AnnotationsPath: []string{"pkg/annotations"},
+						CRDPaths:        []string{"config/crd", "helm"},
+						CRPaths:         []string{"docs/cr"},
 						Metadata: map[string]CRDItem{
 							"crd.with.full.info": {
 								Owners:    []string{"owner"},

--- a/pkg/config/testdata/config1.yaml
+++ b/pkg/config/testdata/config1.yaml
@@ -5,6 +5,8 @@ source_repositories:
     organization: giantswarm
     short_name: apiextensions
     commit_reference: v3.39.0
+    annotations_paths:
+      - pkg/annotations
     crd_paths:
       - config/crd
       - helm

--- a/pkg/config/testdata/config1.yaml
+++ b/pkg/config/testdata/config1.yaml
@@ -5,6 +5,11 @@ source_repositories:
     organization: giantswarm
     short_name: apiextensions
     commit_reference: v3.39.0
+    crd_paths:
+      - config/crd
+      - helm
+    cr_paths:
+      - docs/cr
     metadata:
       crd.with.full.info:
         owner:

--- a/templates/crd.template
+++ b/templates/crd.template
@@ -58,6 +58,18 @@ source_repository_ref: {{ .SourceRepositoryRef }}
 
 # {{ .Title }}
 
+{{- with .Metadata.Deprecation }}
+<p class="well disclaimer">
+<i class="fa fa-warning"></i> <b>Deprecation:</b>
+{{- with .Info }}
+{{ . }}
+{{- end }}
+{{- with .ReplacedBy }}
+This CRD is being replaced by <a href="../{{ .FullName }}/">{{ .ShortName }}</a>.
+{{- end }}
+</p>
+{{- end }}
+
 {{ with .Description }}
 <p class="crd-description">{{ . }}</p>
 {{ end -}}


### PR DESCRIPTION
Closes https://github.com/giantswarm/crd-docs-generator/issues/91

**This is a breaking change. Configuration files have to be adapted to work with this version. In contrast to previous versions, there are no more default paths to search for CRDs, example CRs, or annotations.**

Source paths for CRDs, example CRs, annotations are now configured in the config file.

Three new configuration keys are introduced to configure paths per `source_repository`:

- `crd_paths`: paths to search for CRD YAML files.
- `cr_paths`: paths to search for example CR YAML files.
- `annotations_paths`: paths to search for Go files defining annotations.

All expect array values. Paths are relative to the source repo root. See the `config.example.yaml` file to learn how to use the keys.

## Checklist

- [x] Update changelog in CHANGELOG.md.
