### PR TITLE
Use architect context in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ workflows:
       - architect/push-to-docker:
           name: push-crd-docs-generator-to-quay
           image: quay.io/giantswarm/crd-docs-generator
+          context: architect
           username_envar: QUAY_USERNAME
           password_envar: QUAY_PASSWORD
           requires:


### PR DESCRIPTION
Since credential variables are no longer in the project context, the global "architect" context must be used.