### PR TITLE
Add docker image tag and info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/crd-docs-generator/tree/master.svg?style=shield&circle-token=c0f46d2b8c1482706d8d41b098d488efdf637a1f)](https://circleci.com/gh/giantswarm/crd-docs-generator/tree/master)
-[![Docker Repository on Quay](https://quay.io/repository/giantswarm/crd-docs-generator/status "Docker Repository on Quay")](https://quay.io/repository/giantswarm/crd-docs-generator)
+[![CircleCI](https://circleci.com/gh/giantswarm/crd-docs-generator/tree/master.svg?style=svg&circle-token=2847f4b99edcb9776cbd8ee622b294eb96bfd55f)](https://circleci.com/gh/giantswarm/crd-docs-generator/tree/master)
 
 # crd-docs-generator
 
@@ -23,23 +22,29 @@ This tool relies on:
 
 ## Usage
 
+### Docker
+
 The generator can be executed in Docker using a command like this:
 
 ```nohighlight
 docker run \
     -v $PWD/path/to/output-folder:/opt/crd-docs-generator/output \
     -v $PWD:/opt/crd-docs-generator/config \
-    quay.io/giantswarm/crd-docs-generator \
+    quay.io/giantswarm/crd-docs-generator:0.11.0 \
       --config /opt/crd-docs-generator/config/config.example.yaml
 ```
 
-or in Go like this:
+Here, the tag `0.11.0` is the version number of the crd-docs-generator release you're going to use. Check the [image repository](https://quay.io/repository/giantswarm/crd-docs-generator?tab=tags) for available tags.
+
+The volume mapping defines where the generated output will land.
+
+### Development
+
+With Go installed and this repository cloned, you can exetute the program like this:
 
 ```nohighlight
 go run main.go --config config.example.yaml
 ```
-
-The volume mapping defines where the generated output will land.
 
 See the `config.example.yaml` file for an idea how to configure your source repositories.
 


### PR DESCRIPTION
Solves https://github.com/giantswarm/crd-docs-generator/issues/148

This adds a valid tag to the docker example. In addition, a bit of explanation is given to explain how the docker image tags map to releases.