### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,20 +5,9 @@ orbs:
 workflows:
   build-workflow:
     jobs:
-
-      - architect/go-test:
-          name: go-test-crd-docs-generator
-          # filters is needed to trigger job also on git tag.
-          filters:
-            tags:
-              only: /^v.*/
-
       - architect/go-build:
-          name: go-build-crd-docs-generator
+          name: go-build
           binary: crd-docs-generator
-          requires:
-            - go-test-crd-docs-generator
-          # filters is needed to trigger job also on git tag.
           filters:
             tags:
               only: /^v.*/
@@ -27,7 +16,7 @@ workflows:
           context: architect
           name: push-to-registries
           requires:
-            - go-build-crd-docs-generator
+            - go-build
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.35.1
+  architect: giantswarm/architect@4.35.5
 
 workflows:
   build-workflow:
@@ -23,15 +23,11 @@ workflows:
             tags:
               only: /^v.*/
 
-      - architect/push-to-docker:
-          name: push-crd-docs-generator-to-quay
-          image: quay.io/giantswarm/crd-docs-generator
+      - architect/push-to-registries:
           context: architect
-          username_envar: QUAY_USERNAME
-          password_envar: QUAY_PASSWORD
+          name: push-to-registries
           requires:
             - go-build-crd-docs-generator
-          # filters is needed to trigger job also on git tag.
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- Double-check the job dependecies (`requires`).
- Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- Update the changelog if you think this deserves a mention.
- Approve and merge this PR once it's ready. No need to wait for the author in this case.
- Get this done until 1st of December, so that we can move on with follow-up steps.