### PR TITLE
feat(ci): release darwin and windows binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ workflows:
         platforms: "linux/amd64"
 
     - architect/upload-release-assets:
+        binary: crd-docs-generator
         context: architect
         name: upload-release-assets
         requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@9.0.2
+  architect: giantswarm/architect@9.1.0
 
 workflows:
   build-workflow:
@@ -9,6 +9,7 @@ workflows:
         context: architect
         name: go-build
         binary: crd-docs-generator
+        architectures: "linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64,windows/arm64"
         filters:
           tags:
             only: /^v.*/
@@ -25,3 +26,15 @@ workflows:
             ignore:
             - main
             - master
+        platforms: "linux/amd64"
+
+    - architect/upload-release-assets:
+        context: architect
+        name: upload-release-assets
+        requires:
+        - go-build
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Release binaries now include darwin/amd64, darwin/arm64, windows/amd64, and windows/arm64 alongside the existing linux targets. Windows binaries are named `crd-docs-generator-windows-<arch>.exe`.
 - Switched YAML parser from `gopkg.in/yaml.v3` to `github.com/goccy/go-yaml`.
 
 ## [0.11.4] - 2025-04-23

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM gsoci.azurecr.io/giantswarm/alpine:3.23.4
 
+ARG TARGETARCH
+
 RUN apk add --no-cache ca-certificates git
 
-COPY . /opt/crd-docs-generator
+COPY ./crd-docs-generator-linux-${TARGETARCH} /opt/crd-docs-generator/crd-docs-generator
 
 WORKDIR /opt/crd-docs-generator
 


### PR DESCRIPTION
## What

- `go-build`: adds `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64` to the `architectures` list.
- `upload-release-assets`: uploads signed bare binaries and cosign `.bundle` files to the GitHub Release on tags.
- Bumps architect orb to 9.1.0, which names Windows binaries `<binary>-windows-<arch>.exe` and adds cosign keyless signing and SBOM attestations.

Same pattern as giantswarm/muster#796.
