### PR TITLE
fix(deps): pin transitive modules flagged by the OSS Index scan

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,3 +56,10 @@ replace go.opentelemetry.io/otel/sdk v1.40.0 => go.opentelemetry.io/otel/sdk v1.
 replace golang.org/x/sys v0.40.0 => golang.org/x/sys v0.46.0
 
 replace golang.org/x/text v0.38.0 => golang.org/x/text v0.40.0
+
+// Pin transitive modules flagged by the OSS Index scan (nancy) in CI.
+// go mod tidy would otherwise resolve them below the fixed versions,
+// because nothing imports them directly.
+replace golang.org/x/mod => golang.org/x/mod v0.40.0
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.55.0

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcY
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=
 go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
-golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
+golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=


### PR DESCRIPTION
Same x/mod + x/crypto OSS Index wave as tunnelport#100 / klaus#448 / mcli#196 / area-oncall-scheduler#477 / mcp-prometheus#279 / mcp-capi#182 — nancy fails `go-build` on every branch (currently blocking the Align files PR). Pins the module graph to the fixed versions; verified with tidy x2, `go build ./...`, and `go list -m all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)