### PR TITLE
docs: update CRD reference link to new docs location

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Generates schema reference documentation for Kubernetes Custom Resource Definitions (CRDs).
 
-This tool is built to generate our [Management API CRD schema reference](https://docs.giantswarm.io/ui-api/management-api/crd/).
+This tool is built to generate our [Management API CRD schema reference](https://docs.giantswarm.io/reference/platform-api/crd/).
 
 The generated output consists of Markdown files packed with HTML. By itself, this does not provide a fully readable and user-friendly set of documentation pages. Instead it relies on the HUGO website context, as the [giantswarm/docs](https://github.com/giantswarm/docs) repository, to provide an index page and useful styling.
 


### PR DESCRIPTION
## What
Updated the Management API CRD docs link in the README to the new location.

## Why
docs.giantswarm.io/ui-api/management-api/crd/ returns 404. Giant Swarm moved the CRD reference to docs.giantswarm.io/reference/platform-api/crd/.

## Verification
Old URL 404s, new URL returns 200, confirmed via the docs sitemap.